### PR TITLE
Remove the `hex` unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,3 @@ derive_wrapper = "0.1.3"
 num-integer = "0.1.42"
 num-traits = "0.2.11"
 num-derive = "0.3.0"
-hex = { version = "=0.3.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 #[macro_use]
 pub extern crate derive_wrapper;
 extern crate rand;
-extern crate hex;
 extern crate num_integer;
 extern crate num_derive;
 extern crate num_traits;


### PR DESCRIPTION
It looks like it has already been replaced with the one provided by `bitcoin_hashes`.