### PR TITLE
Support for Tor addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ num-integer = "0.1.42"
 num-traits = "0.2.11"
 num-derive = "0.3.0"
 hex = { version = "=0.3.2" }
+torut = { version = "0.1.1", optional = true }
+
+[features]
+use-tor = ["torut"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ num-integer = "0.1.42"
 num-traits = "0.2.11"
 num-derive = "0.3.0"
 hex = { version = "=0.3.2" }
-torut = { version = "0.1.1", optional = true }
+# Move on using "0.1.2" once <https://github.com/teawithsand/torut/pull/1> will
+# be merged and the new version of `torut` crate will be published
+torut = { git = "https://github.com/LNP-BP/torut", branch = "fix-torkey", optional = true }
 
 [features]
-use-tor = ["torut"]
+use-tor = ["torut/v3"]

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -378,12 +378,12 @@ impl InetSocketAddr {
         Some(Self {
             address: {
                 let mut buf = [0u8; InetAddr::UNIFORM_ADDR_LEN];
-                buf.clone_from_slice(&data[2..]);
+                buf.clone_from_slice(&data[..InetAddr::UNIFORM_ADDR_LEN]);
                 InetAddr::from_uniform_encoding(&buf)?
             },
             port: {
                 let mut buf = [0u8; 2];
-                buf.clone_from_slice(&data[0..2]);
+                buf.clone_from_slice(&data[InetAddr::UNIFORM_ADDR_LEN..]);
                 u16::from_be_bytes(buf)
             }
         })
@@ -392,7 +392,7 @@ impl InetSocketAddr {
     #[inline]
     pub fn to_uniform_encoding(&self) -> [u8; Self::UNIFORM_ADDR_LEN] {
         let mut buf = [0u8; Self::UNIFORM_ADDR_LEN];
-        buf[0..InetAddr::UNIFORM_ADDR_LEN].copy_from_slice(&self.address.to_uniform_encoding());
+        buf[..InetAddr::UNIFORM_ADDR_LEN].copy_from_slice(&self.address.to_uniform_encoding());
         buf[InetAddr::UNIFORM_ADDR_LEN..].copy_from_slice(&self.port.to_be_bytes());
         buf
     }

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -13,14 +13,28 @@
 
 ///! Universal addresses that support IPv4, IPv6 and Tor
 
+use std::fmt;
+use std::convert::TryFrom;
+use std::net::{SocketAddr, Ipv4Addr, Ipv6Addr};
+#[cfg(feature="use-tor")]
+use torut::onion::{TorPublicKeyV3, OnionAddressV3};
+
+#[derive(Clone, Copy, Debug, Display, PartialEq, Eq)]
+#[display_from(Debug)]
 pub enum AddressFormat {
     IPv4,
     IPv6,
+    #[cfg(feature="use-tor")]
     Tor
 }
 
 /// A universal address covering IPv4, IPv6 and Tor in a single byte sequence
-/// of 32 bytes
+/// of 32 bytes.
+///
+/// NB: we are not including 2-byte checksum for Tor addresses, since it
+/// is designed for human-readable part that checks that the address was typed
+/// in correctly. In computer-stored digital data it may be deterministically
+/// regenerated and does not add any additional security.
 ///
 /// Holds either:
 /// * IPv4-to-IPv6 address
@@ -29,30 +43,258 @@ pub enum AddressFormat {
 ///
 /// Tor addresses are distinguished by the fact that last 16 bits
 /// must be set to 0
+#[derive(Clone, Copy)]
 pub union AddressData {
     ipv4: [u8; 4],
     ipv6: [u16; 8],
     tor: [u8; 32],
 }
 
+impl Default for AddressData {
+    fn default() -> Self {
+        Self { tor: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ] }
+    }
+}
+
+impl fmt::Debug for AddressData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe {
+            if cfg!(feature="use-tor") {
+                write!(f, "{:X?}", self.tor)
+            } else {
+                write!(f, "{:X?}", self.ipv6)
+            }
+        }
+    }
+}
+
+
+// Instead of using `From<..>` we use explicit function names to avoid possible
+// bugs with array length confusion for V4 and V6 addresses
+impl AddressData {
+    pub(self) fn from_ipv4(addr: [u8; 4]) -> Self {
+        let mut me = Self::default();
+        me.ipv4 = addr;
+        me
+    }
+
+    pub(self) fn from_ipv6(addr: [u16; 8]) -> Self {
+        let mut me = Self::default();
+        me.ipv6 = addr;
+        me
+    }
+
+    #[cfg(feature="use-tor")]
+    pub(self) fn from_tor(addr: OnionAddressV3) -> Self {
+        let mut me = Self::default();
+        me.ipv6 = addr.get_public_key().as_bytes();
+        me
+    }
+}
+
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Transport {
+    /// Normal TCP
     TCP,
+
+    /// Normal UDP
     UDP,
-    MultipathTCP,
+
+    /// Multipath TCP version
+    MTCP,
+
+    /// More efficient UDP version under developent by Google and consortium of
+    /// other internet companies
     QUIC,
+
+    // There are other rarely used protocols. Do not see any reason to add
+    // them to the LNP/BP stack for now, but it may appear in the future,
+    // so keeping them for referencing purposes:
+    /*
     UDPLite,
     SCTP,
     DCCP,
     RUDP,
+    */
 }
 
+impl TryFrom<String> for Transport {
+    type Error = ();
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let mut val = value.to_lowercase();
+        val.push(':');
+        Ok(match &val[..4] {
+            "tcp:" => Transport::TCP,
+            "udp:" => Transport::UDP,
+            "mtcp" => Transport::MTCP,
+            "quic" => Transport::QUIC,
+            _ => Err(())?
+        })
+    }
+}
+
+impl TryFrom<&str> for Transport {
+    type Error = ();
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_string())
+    }
+}
+
+impl fmt::Display for Transport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}://", match self {
+            Transport::TCP => "tcp",
+            Transport::UDP => "udp",
+            Transport::MTCP => "mtcp",
+            Transport::QUIC => "quic",
+        })
+    }
+}
+
+
+// TODO: Add `PartialEq`, `Eq` to `internet::Address` type
+#[derive(Clone, Copy, Debug)]
 pub struct Address {
+    // Keeping the fields private since they maintain low-level raw data which
+    // shouldn't be access from outside of the structure methods.
     format: AddressFormat,
     data: AddressData,
 }
 
+impl Address {
+    pub fn try_get_ip4(&self) -> Result<Ipv4Addr, ()> {
+        if self.format != AddressFormat::IPv4 { return Err(()) }
+        Ok(Ipv4Addr::from(unsafe { self.data.ipv4 }))
+    }
+
+    pub fn try_get_ip6(&self) -> Result<Ipv6Addr, ()> {
+        if self.format != AddressFormat::IPv6 { return Err(()) }
+        Ok(Ipv6Addr::from(unsafe { self.data.ipv6 }))
+    }
+
+    #[cfg(feature="use-tor")]
+    pub fn try_get_tor(&self) -> Result<OnionAddressV3, ()> {
+        if self.format != AddressFormat::IPv4 { return Err(()) }
+        Ok(OnionAddressV3::from(&TorPublicKeyV3(unsafe { self.data.tor })))
+    }
+}
+
+impl fmt::Display for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let transport = format!("{}://", self.format);
+        let formatted = match self.format {
+            // TODO:
+            AddressFormat::IPv4 => format!("{}", self.try_get_ip4().expect("Rust compiler failure")),
+            AddressFormat::IPv6 => format!("{}", self.try_get_ip6().expect("Rust compiler failure")),
+            #[cfg(feature="use-tor")]
+            AddressFormat::Tor => format!("{}", self.try_get_tor().expect("Rust compiler failure")),
+        };
+        write!(f, "{}", formatted)
+    }
+}
+
+impl From<Ipv4Addr> for Address {
+    fn from(addr: Ipv4Addr) -> Self {
+        Self {
+            format: AddressFormat::IPv4,
+            data: AddressData::from_ipv4(addr.octets())
+        }
+    }
+}
+
+impl From<Ipv6Addr> for Address {
+    fn from(addr: Ipv6Addr) -> Self {
+        Self {
+            format: AddressFormat::IPv6,
+            data: AddressData::from_ipv6(addr.segments())
+        }
+    }
+}
+
+#[cfg(feature="use-tor")]
+impl From<OnionAddressV3> for Address {
+    fn from(addr: OnionAddressV3) -> Self {
+        Self {
+            format: AddressFormat::Tor,
+            data: AddressData::from_tor(addr)
+        }
+    }
+}
+
+// TODO: Implement `PartialEq` and `Eq` for `internet::Socket` when
+//       `internet::Address` will support them
+#[derive(Clone, Copy, Debug, Display)]
+#[display_from(Debug)]
 pub struct Socket {
     pub transport: Transport,
     pub address: Address,
     pub port: u16,
+}
+
+
+// Drafting convertors:
+
+impl From<SocketAddr> for Address {
+    fn from(value: SocketAddr) -> Self {
+        unimplemented!()
+    }
+}
+
+impl TryFrom<String> for Address {
+    type Error = ();
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl TryFrom<&str> for Address {
+    type Error = ();
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl TryFrom<Vec<u8>> for Address {
+    type Error = ();
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Address::try_from(&value[..])
+    }
+}
+
+impl TryFrom<&[u8]> for Address {
+    type Error = ();
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl From<[u8; 4]> for Address {
+    fn from(value: [u8; 4]) -> Self {
+        unimplemented!()
+    }
+}
+
+impl From<[u16; 8]> for Address {
+    fn from(value: [u16; 8]) -> Self {
+        unimplemented!()
+    }
+}
+
+#[cfg(feature="use-tor")]
+impl From<TorPublicKeyV3> for Address {
+    fn from(value: TorPublicKeyV3) -> Self {
+        unimplemented!()
+    }
+}
+
+#[cfg(feature="use-tor")]
+impl TryFrom<[u8; 32]> for Address {
+    type Error = ();
+    fn try_from(value: [u8; 32]) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
 }

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -1,0 +1,58 @@
+// LNP/BP Rust Library
+// Written in 2020 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the MIT License
+// along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+///! Universal addresses that support IPv4, IPv6 and Tor
+
+pub enum AddressFormat {
+    IPv4,
+    IPv6,
+    Tor
+}
+
+/// A universal address covering IPv4, IPv6 and Tor in a single byte sequence
+/// of 32 bytes
+///
+/// Holds either:
+/// * IPv4-to-IPv6 address
+/// * IPv6 address
+/// * Tor address
+///
+/// Tor addresses are distinguished by the fact that last 16 bits
+/// must be set to 0
+pub union AddressData {
+    ipv4: [u8; 4],
+    ipv6: [u16; 8],
+    tor: [u8; 32],
+}
+
+pub enum Transport {
+    TCP,
+    UDP,
+    MultipathTCP,
+    QUIC,
+    UDPLite,
+    SCTP,
+    DCCP,
+    RUDP,
+}
+
+pub struct Address {
+    format: AddressFormat,
+    data: AddressData,
+}
+
+pub struct Socket {
+    pub transport: Transport,
+    pub address: Address,
+    pub port: u16,
+}

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -76,10 +76,10 @@ impl InetAddr {
 }
 
 #[cfg(feature="use-tor")]
-const INET_ADD_LEN: usize = TORV3_PUBLIC_KEY_LENGTH;
+pub const INET_ADDR_LEN: usize = TORV3_PUBLIC_KEY_LENGTH;
 #[cfg(not(feature="use-tor"))]
-const INET_ADD_LEN: usize = 32;
-impl UniformAddrEncodable<INET_ADD_LEN> for InetAddr {
+pub const INET_ADDR_LEN: usize = 32;
+impl UniformAddrEncodable<INET_ADDR_LEN> for InetAddr {
     fn from_uniform_encoding(data: [u8; Self::LEN]) -> Option<Self> {
         match data {
             d if d[0..28] == [0u8; 28] => {
@@ -296,7 +296,8 @@ pub enum Transport {
     */
 }
 
-impl UniformAddrEncodable<1> for Transport {
+pub const TRANSPORT_LEN: usize = 1;
+impl UniformAddrEncodable<TRANSPORT_LEN> for Transport {
     #[inline]
     fn from_uniform_encoding(data: [u8; Self::LEN]) -> Option<Self> {
         use Transport::*;
@@ -367,7 +368,7 @@ impl InetSocketAddr {
     pub fn is_tor(&self) -> bool { self.address.is_tor() }
 }
 
-const INET_SOCKET_ADDR_LEN: usize = InetAddr::LEN + 2;
+pub const INET_SOCKET_ADDR_LEN: usize = INET_ADDR_LEN + 2;
 impl UniformAddrEncodable<INET_SOCKET_ADDR_LEN> for InetSocketAddr {
     #[inline]
     fn from_uniform_encoding(data: [u8; Self::LEN]) -> Option<Self> {
@@ -445,7 +446,7 @@ impl InetSocketAddrExt {
     }
 }
 
-const INET_SOCKET_ADDR_EXT_LEN: usize = InetSocketAddr::LEN + Transport::LEN;
+pub const INET_SOCKET_ADDR_EXT_LEN: usize = INET_SOCKET_ADDR_LEN + TRANSPORT_LEN;
 impl UniformAddrEncodable<INET_SOCKET_ADDR_EXT_LEN> for InetSocketAddrExt {
     #[inline]
     fn from_uniform_encoding(data: [u8; Self::LEN]) -> Option<Self> {

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -16,7 +16,7 @@
 use std::fmt;
 use std::str::FromStr;
 use std::convert::TryFrom;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(feature="use-tor")]
 use torut::onion::{TorPublicKeyV3, OnionAddressV3, TORV3_PUBLIC_KEY_LENGTH};
 
@@ -431,6 +431,13 @@ impl TryFrom<InetSocketAddr> for std::net::SocketAddr {
     #[inline]
     fn try_from(socket_addr: InetSocketAddr) -> Result<Self, Self::Error> {
         Ok(Self::new(IpAddr::try_from(socket_addr.address)?, socket_addr.port))
+    }
+}
+
+impl From<std::net::SocketAddr> for InetSocketAddr {
+    #[inline]
+    fn from(addr: SocketAddr) -> Self {
+        Self::new(addr.ip().into(), addr.port())
     }
 }
 

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -188,12 +188,12 @@ impl Address {
         */
     }
 
-    #[cfg(feature="use-tor")]
+    #[cfg(not(feature="use-tor"))]
     pub fn is_tor(&self) -> bool {
         return false;
     }
 
-    #[cfg(not(feature="use-tor"))]
+    #[cfg(feature="use-tor")]
     pub fn is_tor(&self) -> bool {
         self.format == AddressFormat::Tor
     }

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -101,7 +101,7 @@ impl InetAddr {
     pub fn to_uniform_encoding(&self) -> [u8; Self::UNIFORM_ADDR_LEN] {
         let mut buf = [0u8; Self::UNIFORM_ADDR_LEN];
         match self {
-            InetAddr::IPv4(ipv4_addr) => buf[24..].copy_from_slice(&ipv4_addr.octets()),
+            InetAddr::IPv4(ipv4_addr) => buf[28..].copy_from_slice(&ipv4_addr.octets()),
             InetAddr::IPv6(ipv6_addr) => buf[16..].copy_from_slice(&ipv6_addr.octets()),
             #[cfg(feature="use-tor")]
             InetAddr::Tor(tor_addr) => buf = tor_addr.to_bytes(),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -19,6 +19,7 @@ pub mod macros;
 pub mod as_slice;
 #[macro_use]
 pub mod wrapper;
+pub mod internet;
 
 pub use as_slice::*;
 pub use wrapper::*;


### PR DESCRIPTION
First step in implementing #23 

The code will be proposed to be adopted in `rust-bitcoin`, or on top of both `rust-bitcoin` & `rust-lightning` as a separate crate.