### PR TITLE
Implemented optional support for parse_arg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,12 @@ tokio = { version = "0.2.16", features = ["tcp"], optional = true }
 torut = "0.1.2"
 async-trait = { version = "~0.1", optional = true }
 log = { version = "~0.4", features = ["max_level_trace", "release_max_level_debug"], optional = true }
+parse_arg = { version = "0.1.4", optional = true }
 
 [features]
 default = []
 all = ["use-tor", "use-lightning", "use-tokio", "use-log",
-       "use-bulletproofs", "use-rgb", "use-daemons"]
+       "use-bulletproofs", "use-rgb", "use-daemons", "parse_arg"]
 use-log = ["log"]
 use-tor = ["torut/v3"]
 use-tokio = ["use-lightning", "tokio/tcp", "lightning-net-tokio"]

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -210,6 +210,21 @@ impl TryFrom<Vec<u8>> for InetAddr {
     }
 }
 
+// Yes, I checked that onion addresses don't need to optimize ownership of input String.
+#[cfg(feature = "parse_arg")]
+impl parse_arg::ParseArgFromStr for InetAddr {
+    fn describe_type<W: std::fmt::Write>(mut writer: W) -> std::fmt::Result {
+        #[cfg(not(feature="use-tor"))]
+        {
+            write!(writer, "IPv4 or IPv6 adress")
+        }
+        #[cfg(feature="use-tor")]
+        {
+            write!(writer, "IPv4, IPv6, or Tor (onion) adress")
+        }
+    }
+}
+
 impl TryFrom<&[u8]> for InetAddr {
     type Error = String;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {


### PR DESCRIPTION
This change implements optional support for `parse_arg`, which is used
by `configure_me`. This is needed to use `configure_me` in lnp `wire`.

@dr-orlovsky I interpreted your " :tada: " sign as agreement, so I named the feature `parse_arg` instead of `use-parse_arg`