### PR TITLE
Implemented serde support for InetAddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,14 @@ torut = "0.1.2"
 async-trait = { version = "~0.1", optional = true }
 log = { version = "~0.4", features = ["max_level_trace", "release_max_level_debug"], optional = true }
 parse_arg = { version = "0.1.4", optional = true }
+# This strange naming is a workaround for not being able to define required features for a dependency
+# See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
+serde_crate = { package = "serde", version = "1.0.106", features = ["derive"], optional = true }
 
 [features]
 default = []
 all = ["use-tor", "use-lightning", "use-tokio", "use-log",
-       "use-bulletproofs", "use-rgb", "use-daemons", "parse_arg"]
+       "use-bulletproofs", "use-rgb", "use-daemons", "parse_arg", "serde"]
 use-log = ["log"]
 use-tor = ["torut/v3"]
 use-tokio = ["use-lightning", "tokio/tcp", "lightning-net-tokio"]
@@ -43,3 +46,4 @@ use-bulletproofs = ["grin_secp256k1zkp"]
 use-rgb = ["use-bulletproofs"]
 use-daemons = ["async-trait"]
 use-lightning = ["lightning"]
+serde = ["serde_crate", "torut/serialize"]

--- a/src/common/convert.rs
+++ b/src/common/convert.rs
@@ -1,0 +1,91 @@
+// LNP/BP Rust Library
+// Written in 2020 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//  The convert.rs file written in 2020 by
+//     Martin Habovstiak <martin.habovstiak@gmail.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the MIT License
+// along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+//! This module contains various tools for converting values
+
+/// impls TryFrom<T> where T: Deref<Target=str> in terms of FromStr.
+///
+/// This needs to be a macro instead of blanket imple in order to resolve the
+/// conflict with T: Into<Self>
+#[macro_export]
+macro_rules! impl_try_from_stringly {
+    ($to:ty $(, $from:ty)+ $(,)?) => {
+        $(
+            impl std::convert::TryFrom<$from> for $to {
+                type Error = <$to as FromStr>::Err;
+                #[inline]
+                fn try_from(value: $from) -> Result<Self, Self::Error> {
+                    <$to>::from_str(&value)
+                }
+            }
+        )*
+    }
+}
+
+/// Calls impl_try_from_stringly!() with a set of standard stringly types.
+#[macro_export]
+macro_rules! impl_try_from_stringly_standard {
+    ($type:ty) => {
+        use std::borrow::Cow;
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        impl_try_from_stringly!{ $type,
+            &str,
+            String,
+            Box<str>,
+            Cow<'_, str>,
+            Box<Cow<'_, str>>,
+            Rc<str>,
+            Rc<String>,
+            Rc<Cow<'_, str>>,
+            Arc<str>,
+            Arc<String>,
+            Arc<Cow<'_, str>>,
+
+        }
+
+        #[cfg(feature="serde")]
+        impl_try_from_stringly!($type, crate::common::serde::CowHelper<'_>);
+    }
+}
+
+/// Impls From<T> for Stringly where String: Into<Stringly>, T: Display
+#[macro_export]
+macro_rules! impl_into_stringly {
+    ($from:ty $(, $into:ty)+ $(,)?) => {
+        $(
+            impl From<$from> for $into {
+                fn from(value: $from) -> Self {
+                    value.to_string().into()
+                }
+            }
+        )+
+    }
+}
+
+macro_rules! impl_into_stringly_standard {
+    ($type:ty) => {
+        impl_into_stringly! { $type,
+            String,
+            Box<str>,
+            Cow<'_, str>,
+            Rc<str>,
+            Rc<String>,
+            Arc<str>,
+            Arc<String>,
+        }
+    }
+}

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -19,6 +19,8 @@ use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 #[cfg(feature="use-tor")]
 use torut::onion::{TorPublicKeyV3, OnionAddressV3, TORV3_PUBLIC_KEY_LENGTH};
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 
 /// A universal address covering IPv4, IPv6 and Tor in a single byte sequence
@@ -39,6 +41,7 @@ use torut::onion::{TorPublicKeyV3, OnionAddressV3, TORV3_PUBLIC_KEY_LENGTH};
 /// Tor addresses are distinguished by the fact that last 16 bits
 /// must be set to 0
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
 pub enum InetAddr {
     IPv4(Ipv4Addr),
     IPv6(Ipv6Addr),

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -180,13 +180,8 @@ impl From<OnionAddressV3> for InetAddr {
     fn from(addr: OnionAddressV3) -> Self { InetAddr::Tor(addr.get_public_key()) }
 }
 
-impl TryFrom<String> for InetAddr {
-    type Error = String;
-    #[inline]
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        InetAddr::from_str(value.as_str())
-    }
-}
+impl_try_from_stringly_standard!(InetAddr);
+impl_into_stringly_standard!(InetAddr);
 
 impl FromStr for InetAddr {
     type Err = String;

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -22,7 +22,6 @@ use torut::onion::{TorPublicKeyV3, OnionAddressV3, TORV3_PUBLIC_KEY_LENGTH};
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
 
-
 /// A universal address covering IPv4, IPv6 and Tor in a single byte sequence
 /// of 32 bytes.
 ///
@@ -41,7 +40,7 @@ use serde::{Serialize, Deserialize};
 /// Tor addresses are distinguished by the fact that last 16 bits
 /// must be set to 0
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(try_from = "crate::common::serde::CowHelper", into = "String", crate = "serde_crate"))]
 pub enum InetAddr {
     IPv4(Ipv4Addr),
     IPv6(Ipv6Addr),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,6 +16,8 @@
 
 #[macro_use]
 pub mod macros;
+#[macro_use]
+pub(crate) mod convert;
 pub mod as_slice;
 #[macro_use]
 pub mod wrapper;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -22,6 +22,8 @@ pub mod wrapper;
 pub mod internet;
 #[cfg(feature="use-daemons")]
 pub mod service;
+#[cfg(feature="serde")]
+pub(crate) mod serde;
 
 pub use as_slice::*;
 pub use wrapper::*;

--- a/src/common/serde.rs
+++ b/src/common/serde.rs
@@ -1,0 +1,40 @@
+// LNP/BP Rust Library
+// Written in 2020 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//  The serde.rs file written in 2020 by
+//     Martin Habovstiak <martin.habovstiak@gmail.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the MIT License
+// along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+//! This module contains primitives used to implement serde support.
+
+use serde::Deserialize;
+use std::borrow::Cow;
+use std::ops::Deref;
+
+/// This is a helper for deserializing using `FromStr` more efficiently.
+///
+/// The implementation of Deserialize for Cow doesn't borrow the string,
+/// so it allocates needlessly if the string is going to be passed to `FromStr`.
+///
+/// Our CowHelper is written such that it borrows the str, avoiding the
+/// allocation.
+#[cfg(feature = "serde")]
+#[derive(Deserialize)]
+#[serde(crate = "serde_crate")]
+pub(crate) struct CowHelper<'a>(#[serde(borrow)] Cow<'a, str>);
+
+impl<'a> Deref for CowHelper<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ pub extern crate lightning;
 pub extern crate miniscript;
 #[cfg(feature="use-bulletproofs")]
 pub extern crate secp256k1zkp;
+#[cfg(feature = "serde")]
+extern crate serde_crate as serde;
 
 #[macro_use]
 pub mod common;

--- a/src/lnp/transport.rs
+++ b/src/lnp/transport.rs
@@ -98,6 +98,8 @@ impl FromStr for NodeAddr {
     }
 }
 
+impl_try_from_stringly_standard!(NodeAddr);
+impl_into_stringly_standard!(NodeAddr);
 
 #[derive(Debug, Display)]
 #[display_from(Debug)]

--- a/src/lnp/transport.rs
+++ b/src/lnp/transport.rs
@@ -26,6 +26,8 @@ use tokio::net::TcpStream;
 use tokio::io::AsyncWriteExt;
 #[cfg(feature="use-tokio")]
 use tokio::io::AsyncReadExt;
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 #[cfg(not(feature="use-tokio"))]
 use std::net::TcpStream;
@@ -48,6 +50,7 @@ use super::LIGHTNING_P2P_DEFAULT_PORT;
 pub const MAX_TRANSPORT_FRAME_SIZE: usize = 65569;
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(try_from = "crate::common::serde::CowHelper", into = "String", crate = "serde_crate"))]
 pub struct NodeAddr {
     pub node_id: secp256k1::PublicKey,
     pub inet_addr: InetSocketAddr,


### PR DESCRIPTION
This implements optional `serde` support, so far only for InetAddr. It'd
be nice to implement it for other things, but this is minimum
requirement for implementing `configure_me`.

~~Unresolved question: should we defer to the default implementation or
redirect it to `FromStr`, so that the values in config files are nicer?~~

I decided to go with stringly serialization because arguments use it too and it'd be weird to write `nodeaddr@host:port` on command line, but something like:

```
[[connect]]
pubkey: "..."
host: "..."
port: 9735
```

in the config.

As an alternative we could support the format above as an alternative form of deserialization, but I suggest to put this off until someone actually needs it. There are more important things to do now.