### PR TITLE
Avoid using private dependency of lightning crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ parse_arg = { version = "0.1.4", optional = true }
 # This strange naming is a workaround for not being able to define required features for a dependency
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
 serde_crate = { package = "serde", version = "1.0.106", features = ["derive"], optional = true }
+secp256k1 = { version = "0.17.2", optional = true }
 
 [features]
 default = []
@@ -45,5 +46,5 @@ use-tokio = ["use-lightning", "tokio/tcp", "lightning-net-tokio"]
 use-bulletproofs = ["grin_secp256k1zkp"]
 use-rgb = ["use-bulletproofs"]
 use-daemons = ["async-trait"]
-use-lightning = ["lightning"]
+use-lightning = ["lightning", "secp256k1"]
 serde = ["serde_crate", "torut/serialize"]

--- a/src/lnp/peer.rs
+++ b/src/lnp/peer.rs
@@ -14,8 +14,6 @@
 //! BOLT-1. Manages state of the remote peer and handles direct communications
 //! with it. Relies on transport layer (BOLT-8-based) protocol.
 
-use lightning::secp256k1;
-
 use super::transport::*;
 
 

--- a/src/lnp/transport.rs
+++ b/src/lnp/transport.rs
@@ -36,8 +36,6 @@ use std::io::AsyncWriteExt;
 #[cfg(not(feature="use-tokio"))]
 use std::io::AsyncReadExt;
 
-use lightning::secp256k1;
-
 // We re-export this under more proper name (it's not per-channel encryptor,
 // it is per-connection transport-level encryptor)
 use lightning::ln::peers::conduit::Conduit as Encryptor;


### PR DESCRIPTION
The secp256k1 dependency is not declared as public, yet this crate
depended on it. This was preiously accepted by the compiler, but it's
disabled in the newest versions.

This change uses the `secp256k1` crate directly instead.

It might be actually better for `rust-lightning` to reexport the module or some types, but I will need to take some time to write a coherent explanation why that's a good thing.

FYI This is a part of attempt to update to the newer version of lightning in order to test if link problems were solved.