### PR TITLE
Various fixes

### DIFF
--- a/src/rgb/vm/embedded.rs
+++ b/src/rgb/vm/embedded.rs
@@ -110,7 +110,7 @@ impl Embedded {
                                 vec![
                                     amount::Revealed {
                                         amount: supply,
-                                        blinding: secp256k1zkp::key::ZERO_KEY,
+                                        blinding: secp256k1zkp::key::ONE_KEY,
                                     }
                                     .conceal()
                                     .commitment,


### PR DESCRIPTION
* Fixes again the blinding factors generation
* Changes TxResolver to be a Trait so that we can use a complex struct as a resolver. It's useful if the resolver has some internal state that can be reused, like a connection to an Electrum server or a Bitcoin Core RPC.