### PR TITLE
Changes Blinding factor from 32 bit to 64 bit.

### DIFF
--- a/src/bp/blind.rs
+++ b/src/bp/blind.rs
@@ -25,7 +25,7 @@ use crate::commit_verify::CommitVerify;
 pub struct OutpointReveal {
     /// Blinding factor preventing rainbow table bruteforce attack based on
     /// the existing blockchain txid set
-    pub blinding: u32,
+    pub blinding: u64,
 
     /// Txid that should be blinded
     pub txid: Txid,
@@ -44,7 +44,7 @@ impl From<OutpointReveal> for OutPoint {
 impl From<OutPoint> for OutpointReveal {
     fn from(outpoint: OutPoint) -> Self {
         Self {
-            blinding: thread_rng().next_u32(),
+            blinding: thread_rng().next_u64(),
             txid: outpoint.txid,
             vout: outpoint.vout as u16,
         }

--- a/src/bp/strict_encoding.rs
+++ b/src/bp/strict_encoding.rs
@@ -100,7 +100,7 @@ impl StrictDecode for secp256k1::Signature {
 
     #[inline]
     fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Self::Error> {
-        let mut buf = [0u8; secp256k1::constants::PUBLIC_KEY_SIZE];
+        let mut buf = [0u8; secp256k1::constants::COMPACT_SIGNATURE_SIZE];
         d.read_exact(&mut buf)?;
         Ok(Self::from_compact(&buf).map_err(|_| {
             Error::DataIntegrityError("Invalid secp256k1 signature data".to_string())

--- a/src/bp/strict_encoding.rs
+++ b/src/bp/strict_encoding.rs
@@ -247,7 +247,7 @@ impl StrictDecode for OutpointReveal {
     #[inline]
     fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Self::Error> {
         Ok(Self {
-            blinding: u32::strict_decode(&mut d)?,
+            blinding: u64::strict_decode(&mut d)?,
             txid: Txid::strict_decode(&mut d)?,
             vout: u16::strict_decode(&mut d)?,
         })

--- a/src/rgb/contract/seal.rs
+++ b/src/rgb/contract/seal.rs
@@ -28,7 +28,7 @@ pub enum Revealed {
     /// Seal that is revealed
     TxOutpoint(OutpointReveal),
     /// Seal contained within the witness transaction
-    WitnessVout { vout: u16, blinding: u32 },
+    WitnessVout { vout: u16, blinding: u64 },
 }
 
 impl Revealed {
@@ -105,7 +105,7 @@ mod strict_encoding {
                 0u8 => Revealed::TxOutpoint(OutpointReveal::strict_decode(d)?),
                 1u8 => Revealed::WitnessVout {
                     vout: u16::strict_decode(&mut d)?,
-                    blinding: u32::strict_decode(&mut d)?,
+                    blinding: u64::strict_decode(&mut d)?,
                 },
                 invalid => Err(Error::EnumValueNotKnown(
                     "seal::Confidential".to_string(),


### PR DESCRIPTION
Changes the blinding factor from 32 bit to 64 bit as suggested by [Issue#51](https://github.com/LNP-BP/rust-lnpbp/issues/51)

- Full build compiled
- one test failure with `all` features at 
```
test rgb::stash::consignment::test::test_consignment_validation ... FAILED
failures:

---- rgb::stash::consignment::test::test_consignment_validation stdout ----
thread 'rgb::stash::consignment::test::test_consignment_validation' panicked at 'called `Result::unwrap()` on an `Err` value: UnsupportedDataStructure("We support only homomorphic commitments to U64 data")', src/rgb/stash/consignment.rs:124:47
```
With the following backtrace
```
13: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  14: core::option::expect_none_failed
             at src/libcore/option.rs:1269
  15: core::result::Result<T,E>::unwrap
             at /home/raj/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/result.rs:1005
  16: lnpbp::rgb::stash::consignment::test::consignment
             at src/rgb/stash/consignment.rs:124
  17: lnpbp::rgb::stash::consignment::test::test_consignment_validation
             at src/rgb/stash/consignment.rs:136
  18: lnpbp::rgb::stash::consignment::test::test_consignment_validation::{{closure}}
             at src/rgb/stash/consignment.rs:135
  19: core::ops::function::FnOnce::call_once
             at /home/raj/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/ops/function.rs:233
```
I can't seem to identify the source of the decoding error. My guess is this raw consignment data needs to be modified with 64-bit blinds.  
https://github.com/LNP-BP/rust-lnpbp/blob/2f6fee732417aad5c71fcd0120ed0db4b1e61061/src/rgb/stash/consignment.rs#L95-L98



- As I was already touching the `src/bp/strict_encoding.rs`, I have slid in another small change that fixes a buffer misallocation bug. It seemed obvious to me that the signature read buffer size was wrong, but not sure why it wasn't causing any upstream failure. If I am missing something and it was supposed to be what it was, will revert the commit. 