### PR TITLE
Added Support for Tor V2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ num-traits = "~0.2.11"
 num-derive = "~0.3.0"
 tokio = { version = "~0.2.18", features = ["tcp", "sync"], optional = true }
 futures = "~0.3.4"
-torut = "~0.1.2"
+torut = { version = "~0.1.2", features = ["v2", "v3"] }
 async-trait = { version = "~0.1.30", optional = true }
 log = { version = "~0.4.8", features = ["max_level_trace", "release_max_level_debug"], optional = true }
 zmq = { version = "~0.9.2", optional = true }

--- a/src/bp/scripts/types.rs
+++ b/src/bp/scripts/types.rs
@@ -22,7 +22,7 @@
 //! output script, btu not vice versa. But really what makes a "script" is just the fact that it's
 //! formatted correctly.
 //!
-//! While all `Script`s represent the same same type **semantically**, there is a clear distinction
+//! While all `Script`s represent the same type **semantically**, there is a clear distinction
 //! at the **logical** level: Bitcoin script has the property to be committed into some other
 //! Bitcoin script – in a nested structures like in several layers, like *redeemScript* inside of
 //! *sigScript* used for P2SH, or *tapScript* within *witnessScript* coming from *witness* field
@@ -31,7 +31,7 @@
 //! public keys (`PubkeyHash`, `WPubkeyHash`), while other contain the full source of the script.
 //!
 //! The present type system represents a solution to the problem: it distinguish different logical
-//! types by introducing `Script` wrapper types. It defines `LockScript` as bottom layer or a script
+//! types by introducing `Script` wrapper types. It defines `LockScript` as bottom layer of a script
 //! hierarchy, containing no other script commitments (in form of their hashes). It also defines
 //! types above on it: `PubkeyScript` (for whatever is there in `pubkeyScript` field of a `TxOut`),
 //! `SigScript` (for whatever comes from `sigScript` field of `TxIn`), `RedeemScript` and `TapScript`.
@@ -461,7 +461,7 @@ impl ScriptSet {
         self.witness_script != None
     }
 
-    /// Detects whether the structure is either P2SH-P2WPKH or P2SH-P2WPSH
+    /// Detects whether the structure is either P2SH-P2WPKH or P2SH-P2WSH
     pub fn is_witness_sh(&self) -> bool {
         return self.sig_script.as_inner().len() > 0 && self.has_witness();
     }

--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -28,7 +28,7 @@ use torut::onion::{OnionAddressV3, TorPublicKeyV3, TORV3_PUBLIC_KEY_LENGTH};
 /// * Tor address (only 3rd version is supported)
 ///
 /// NB: we are using `TorPublicKeyV3` instead of `OnionAddressV3`, since
-/// `OnionAddressV3` keeps cehcksum and other information wich can be
+/// `OnionAddressV3` keeps cehcksum and other information which can be
 /// reconstructed from `TorPublicKeyV3`. The 2-byte checksum in `OnionAddressV3`
 /// is designed for human-readable part that checks that the address was typed
 /// in correctly. In computer-stored digital data it may be deterministically

--- a/src/common/service.rs
+++ b/src/common/service.rs
@@ -29,7 +29,7 @@ pub trait TryService: Sized {
             Err(err) => format!("{} run loop has failed with error {}", service_name, err),
             Ok(_) => format!("{} has failed without reporting a error", service_name),
         };
-        #[cfg(fature = "log")]
+        #[cfg(feature = "log")]
         error!("{}", message);
         panic!("{}", message);
     }

--- a/src/lnp/session/connection.rs
+++ b/src/lnp/session/connection.rs
@@ -91,6 +91,7 @@ impl Connection {
         #[cfg(feature = "tor")]
         let socket_addr: SocketAddr = node
             .inet_addr
+            .clone()
             .try_into()
             .map_err(|_| ConnectionError::TorNotYetSupported)?;
         #[cfg(not(feature = "tor"))]

--- a/src/lnp/session/node_addr.rs
+++ b/src/lnp/session/node_addr.rs
@@ -20,7 +20,7 @@ use super::{Connection, ConnectionError};
 use crate::internet::InetSocketAddr;
 use crate::lnp::LIGHTNING_P2P_DEFAULT_PORT;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/src/paradigms/single_use_seals.rs
+++ b/src/paradigms/single_use_seals.rs
@@ -137,7 +137,7 @@ pub trait SingleUseSeal {
 /// version of the SealMedium [AsyncSealMedium], which requires use of
 /// `async` feature of this crate.
 ///
-/// All these operations are medium-specific; for the same sinle-use-seal type
+/// All these operations are medium-specific; for the same single-use-seal type
 /// they may differ when are applied to different proof of publication mediums.
 ///
 /// To read more on proof-of-publication please check


### PR DESCRIPTION
Minimal Tor Onion V2 address support has been implemented as per [Issue#29](https://github.com/LNP-BP/rust-lnpbp/issues/29)

Due to upstream incompatibility, for now, `OnionAddressV2` can only be constructed from an address string and not from a byte array, unlike other `InetAddr` variants.

`OnionAddressV2` Doesn't implement Copy, thus Copy derivation has been removed from `InteAddr` which causes change in some other part of the libraries which is bundled in the last commit.

The library compiles and unit tests passing.

Note: I haven't tried rust-rgb to see if anything breaks there because of removing Copy Dervitation, will check later and update.  