### PR TITLE
Use 32-bit integers for transaction output indexes in single-use seals

### DIFF
--- a/src/bp/blind.rs
+++ b/src/bp/blind.rs
@@ -31,7 +31,7 @@ pub struct OutpointReveal {
     pub txid: Txid,
 
     /// Tx output number that should be blinded
-    pub vout: u16,
+    pub vout: u32,
 }
 
 impl From<OutpointReveal> for OutPoint {
@@ -46,7 +46,7 @@ impl From<OutPoint> for OutpointReveal {
         Self {
             blinding: thread_rng().next_u64(),
             txid: outpoint.txid,
-            vout: outpoint.vout as u16,
+            vout: outpoint.vout as u32,
         }
     }
 }

--- a/src/bp/strict_encoding.rs
+++ b/src/bp/strict_encoding.rs
@@ -249,7 +249,7 @@ impl StrictDecode for OutpointReveal {
         Ok(Self {
             blinding: u64::strict_decode(&mut d)?,
             txid: Txid::strict_decode(&mut d)?,
-            vout: u16::strict_decode(&mut d)?,
+            vout: u32::strict_decode(&mut d)?,
         })
     }
 }

--- a/src/rgb/contract/seal.rs
+++ b/src/rgb/contract/seal.rs
@@ -28,7 +28,7 @@ pub enum Revealed {
     /// Seal that is revealed
     TxOutpoint(OutpointReveal),
     /// Seal contained within the witness transaction
-    WitnessVout { vout: u16, blinding: u64 },
+    WitnessVout { vout: u32, blinding: u64 },
 }
 
 impl Revealed {
@@ -104,7 +104,7 @@ mod strict_encoding {
             Ok(match format {
                 0u8 => Revealed::TxOutpoint(OutpointReveal::strict_decode(d)?),
                 1u8 => Revealed::WitnessVout {
-                    vout: u16::strict_decode(&mut d)?,
+                    vout: u32::strict_decode(&mut d)?,
                     blinding: u64::strict_decode(&mut d)?,
                 },
                 invalid => Err(Error::EnumValueNotKnown(


### PR DESCRIPTION
This solves [Issue#45](https://github.com/LNP-BP/rust-lnpbp/issues/45)

The change is fairly trivial unless I am missing something.

Build + Tests passes. 