### PR TITLE
Fixes build failure due to rust-1.47.0 update

### DIFF
--- a/src/common/internet.rs
+++ b/src/common/internet.rs
@@ -28,7 +28,7 @@ use torut::onion::{OnionAddressV3, TorPublicKeyV3, TORV3_PUBLIC_KEY_LENGTH};
 /// * Tor address (only 3rd version is supported)
 ///
 /// NB: we are using `TorPublicKeyV3` instead of `OnionAddressV3`, since
-/// `OnionAddressV3` keeps cehcksum and other information wich can be
+/// `OnionAddressV3` keeps cehcksum and other information which can be
 /// reconstructed from `TorPublicKeyV3`. The 2-byte checksum in `OnionAddressV3`
 /// is designed for human-readable part that checks that the address was typed
 /// in correctly. In computer-stored digital data it may be deterministically

--- a/src/rgb/contract/amount.rs
+++ b/src/rgb/contract/amount.rs
@@ -89,7 +89,7 @@ impl ConfidentialState for Confidential {}
 
 impl PartialOrd for Confidential {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match (&self.commitment.0).partial_cmp(&other.commitment.0[..]) {
+        match (&self.commitment.0).partial_cmp(&other.commitment.0) {
             None => None,
             Some(Ordering::Equal) => self.bulletproof.proof[0..self.bulletproof.plen]
                 .partial_cmp(&other.bulletproof.proof[0..other.bulletproof.plen]),


### PR DESCRIPTION
This solves rgb-node [Issue#29](https://github.com/LNP-BP/rgb-node/issues/29)

The compilation error was due to rust-nightly update to version 1.47.0.

Build passes except a test which should pass after updating the test data.
```
failures:

---- rgb::stash::consignment::test::test_consignment_validation stdout ----
thread 'rgb::stash::consignment::test::test_consignment_validation' panicked at 'called `Result::unwrap()` on an `Err` value: UnsupportedDataStructure("We support only homomorphic commitments to U64 data")', src/rgb/stash/consignment.rs:124:47


failures:
    rgb::stash::consignment::test::test_consignment_validation

test result: FAILED. 60 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '-p lnpbp --lib'
```

Verified RGB build passing against this PR.
```
   Compiling rgb_node v0.1.0-beta.2 (/home/raj/github-repo/rgb-node)
warning: use of deprecated item 'std::vec::Vec::<T>::remove_item': Removing the first item equal to a needle is already easily possible with iterators and the current Vec methods. Furthermor
, having a method for one particular case of removal (linear search, only the first item, no swap remove) but not for others is inconsistent. This method will be removed soon.
   --> src/contracts/fungible/data/asset.rs:171:21
    |
171 |         allocations.remove_item(&old_allocation).is_some()
    |                     ^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 2m 54s
```  
