### PR TITLE
Added test coverage for Metadata structures

### DIFF
--- a/src/rgb/contract/field.rs
+++ b/src/rgb/contract/field.rs
@@ -209,3 +209,147 @@ mod strict_encoding {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::super::testutils::*;
+    use super::*;
+    //use crate::amplify::Wrapper;
+    //use crate::paradigms::client_side_validation::CommitEncode;
+    use crate::paradigms::strict_encoding::StrictDecode;
+
+    // Hard coded sample metadata object as shown below
+    // Metadata({13: {U8(2), U8(3), U16(2), U32(2), U32(3),
+    //    U64(2), U64(3), I8(2), I8(3), I32(2), I32(3),
+    //    I64(2), I64(3), F32(2.0), F32(3.0), F64(2.0),
+    //    F64(3.0), Bytes([1, 2, 3, 4, 5]), Bytes([10, 20, 30, 40, 50]),
+    //    String("One Random String"), String("Another Random String")}})
+    // It has Field_type = 13 with only single U16 and no I16 data types.
+    static METADATA: [u8; 161] = [
+        0x1, 0x0, 0xd, 0x0, 0x15, 0x0, 0x0, 0x2, 0x0, 0x3, 0x1, 0x2, 0x0, 0x2, 0x2, 0x0, 0x0, 0x0,
+        0x2, 0x3, 0x0, 0x0, 0x0, 0x3, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3, 0x3, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x8, 0x2, 0x8, 0x3, 0xa, 0x2, 0x0, 0x0, 0x0, 0xa, 0x3, 0x0, 0x0,
+        0x0, 0xb, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xb, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x12, 0x0, 0x0, 0x0, 0x40, 0x12, 0x0, 0x0, 0x40, 0x40, 0x13, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x40, 0x13, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8, 0x40, 0x20, 0x5, 0x0, 0x1, 0x2,
+        0x3, 0x4, 0x5, 0x20, 0x5, 0x0, 0xa, 0x14, 0x1e, 0x28, 0x32, 0x21, 0x11, 0x0, 0x4f, 0x6e,
+        0x65, 0x20, 0x52, 0x61, 0x6e, 0x64, 0x6f, 0x6d, 0x20, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67,
+        0x21, 0x15, 0x0, 0x41, 0x6e, 0x6f, 0x74, 0x68, 0x65, 0x72, 0x20, 0x52, 0x61, 0x6e, 0x64,
+        0x6f, 0x6d, 0x20, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67,
+    ];
+
+    #[test]
+    fn test_extraction() {
+        let metadata = Metadata::strict_decode(&METADATA[..]).unwrap();
+
+        let field_type = 13 as schema::FieldType;
+
+        let field_1 = metadata.u8(field_type);
+        let field_2 = metadata.u16(field_type);
+        let field_3 = metadata.u32(field_type);
+        let field_4 = metadata.u64(field_type);
+        let field_5 = metadata.i8(field_type);
+        let field_6 = metadata.i16(field_type);
+        let field_7 = metadata.i32(field_type);
+        let field_8 = metadata.i64(field_type);
+        let field_9 = metadata.f32(field_type);
+        let field_10 = metadata.f64(field_type);
+        let field_11 = metadata.bytes(field_type);
+        let field_12 = metadata.string(field_type);
+
+        assert_eq!(
+            field_1,
+            FieldData {
+                data: vec![2, 3],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_2,
+            FieldData {
+                data: vec![2],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_3,
+            FieldData {
+                data: vec![2, 3],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_4,
+            FieldData {
+                data: vec![2, 3],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_5,
+            FieldData {
+                data: vec![2, 3],
+                next: 0
+            }
+        );
+        assert_eq!(field_6, FieldData::empty());
+        assert_eq!(
+            field_7,
+            FieldData {
+                data: vec![2, 3],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_8,
+            FieldData {
+                data: vec![2, 3],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_9,
+            FieldData {
+                data: vec![2 as f32, 3 as f32],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_10,
+            FieldData {
+                data: vec![2 as f64, 3 as f64],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_11,
+            FieldData {
+                data: vec![[1u8, 2, 3, 4, 5].to_vec(), [10u8, 20, 30, 40, 50].to_vec()],
+                next: 0
+            }
+        );
+        assert_eq!(
+            field_12,
+            FieldData {
+                data: vec![
+                    "One Random String".to_string(),
+                    "Another Random String".to_string()
+                ],
+                next: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_encode_decode_meta() {
+        test_encode!((METADATA, Metadata));
+    }
+
+    #[test]
+    fn test_iteration_field() {
+        let metadata = Metadata::strict_decode(&METADATA[..]).unwrap();
+        let field_values = metadata.f32(13 as schema::FieldType);
+
+        assert_eq!(field_values.into_iter().sum::<f32>(), 5f32);
+    }
+}


### PR DESCRIPTION
This adds test coverage for `Metadata` structures. Let me know if anything more needs to be added.  