### PR TITLE
README: fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The library is based on other projects:
 
 On Debian, run
 ```shell script
-sudo apt-get install cargo
+sudo apt-get install cargo libzmq3-dev
 ```
 
 On Mac OS, run
@@ -119,7 +119,7 @@ brew cargo
 ```shell script
 git clone https://github.com/lnp-bp/rust-lnpbp
 cd rust-lnpbp
-cargo build --release
+cargo build --release --features vendored_openssl
 ```
 
 The library can be found in `target/release` directory.


### PR DESCRIPTION
- add `libzmq3-dev` dependency to avoid the `No package 'libzmq' found` error
- add `--features vendored_openssl` flag to avoid the `openssl/opensslconf.h not found` error