### PR TITLE
Release v0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,71 @@ Change Log
 v0.1.0
 ------
 
-### Breaking changes:
+### Library overview
+- **Paradigms**: generic APIs for L1/L3 best practices
+  * **Client-side validation**
+  * **Single-use-seals**
+  * **Strict encoding**
+- **Bitcoin protocol**: extensions to `bitcoin` crate and L2/L3 APIs
+  * **Deterministic bitcoin commitments** (DBC) based on LNPBP1-4 standard
+  * **Tagged hashes**: additional procedures for working with Tapproot-style
+    tagged hashes
+  * **Short bitcoin identifiers** based on LNPBP-4 standard
+  * **Resolver API** for requesting transaction graph using providers (like
+    Bitcoin Core RPC, Electrum Server API etc)
+  * **Chains**, chain parameters and universal asset identifiers
+  * **Script types** for differentiating script cycle through different
+    transaction parts
+  * **Transaction-output-based single-use-seals**: bitcoin-specific 
+    implementation of single-use-seals
+- **RGB**: confidential smart-contract system for Bitcoin & Lightning Network
+  based on client-side validation paradigm (LNPBP11-13 standards)
+  * **Schema**: structure defining contract creation and evolution rules and
+    restrictions
+  * **Contracts**: data types for contract lifecycle
+  * **Scripting** with embedded procedures for fungible assets  
+  *The library implements RGB Core v1 release candidate set of standards*
+- **Lightning networking protocol**: generalized P2P and RPC networking APIs
+  based on the original Lightning standard; early preview
+  * Universal P2P node ids supporting IPv4, IPv6, Onion v2 and v3 addresses and
+    public keys
+  * Feature vectors for defining and workinf with set of feature bits
+  * LNP networking with ZMQ sockets for RPC interfaces
+
+### Major changes since RC2
+- Support for Rust stable and MSRV reduction to 1.41.1
+- Custom forks for upstream bitcoin-related dependencies are changed onto the
+  latest publicly-released versions
+
+### Breaking changes since RC2
+- Updated taproot-based hashed tag system (BIP-340) according to the most
+  recent specs.
 - RGB `Amount` renamed into `AtomicValue`
 - RGB `amount` mod renamed into `value`
 - RGB seal definitions and related structures are now `Copy` and returned by 
   value
 
-### Other changes:
 
 v0.1.0-rc.2
 -----------
 
 ### Breaking changes:
 - Changed embedded procedure names for RGB VM
-- Removed requirement for PSBT to contain fee key in RGB anchor creation (it needs to be a properly constructed PSBT with `witness_utxo`/`non_witness_utxo` data)
+- Removed requirement for PSBT to contain fee key in RGB anchor creation (it 
+  needs to be a properly constructed PSBT with `witness_utxo`/`non_witness_utxo` 
+  data)
 
 ### Other changes:
-- Schema serialization
 - More embedded procedures for RGB VM
-- Serde serialization for all RGB structures
+- Schema serde serialization (YAML, JSON etc)
+- Serde serialization for all RGB contract structures
 - Strict encoding and decoding of Curve25519 public keys and Ed25519 signatures
-- Implementation of Curve25519 public keys and Ed25519 signatures as RGB state and metadata
+- Implementation of Curve25519 public keys and Ed25519 signatures as RGB state 
+  and metadata
 - Bech types for Pedersen commitments, Bulletproofs, Curve25519 data
 - Tweaking factor is added into PSBT information during anchor creation
+- Added bitcoin protocol resolvers API
+
 
 v0.1.0-rc.1
 -----------
@@ -46,13 +88,17 @@ v0.1.0-rc.1
 - Test coverage >70%
 - Code docs >50%
 
+
 v0.1.0-beta.4
 -------------
 
 ### Breaking changes:
-- Updated upstream crates (bitcoin, bitcoin_hashes, secp256k1, grin_secp256k1zpk, miniscript, lightning) with many PRs merged
-- EmbedCommitVerify now can mutate container data (used for returning tweaking factors)
-- Upgrading `rand` version to the most recent one (blocked previously by grin_secp256k1zpk dependency)
+- Updated upstream crates (bitcoin, bitcoin_hashes, secp256k1, 
+  grin_secp256k1zpk, miniscript, lightning) with many PRs merged
+- EmbedCommitVerify now can mutate container data (used for returning tweaking 
+  factors)
+- Upgrading `rand` version to the most recent one (blocked previously by 
+  grin_secp256k1zpk dependency)
 - Changied txout seals to use u32 vouts instead of u16
 - Changed txout blinding factor to be u64 instead of u32
 
@@ -67,7 +113,8 @@ v0.1.0-beta.3
 
 ### Breaking changes
 - Single-use-seals blinding factor changed from 32-bit to 64-bit of entropy
-- Transaction output indexes in single-use-seal definitions are now 32-bit, as in Bitcoin Core / rust-bitcoin (previously were 16-bit)
+- Transaction output indexes in single-use-seal definitions are now 32-bit, as 
+  in Bitcoin Core / rust-bitcoin (previously were 16-bit)
 
 ### New features
 - Initial Tor V2 address support
@@ -80,13 +127,21 @@ v0.1.0-beta.2
 ### Features overview
 - Complete validation workflow with new Validator object
 - Virtual machines for RGB contracts (interface + embedded VM)
-- `Consignment` now has a version field, so in the future more space-saving variants can be created (like removing txid from anchors and using short universal bitcoin IDs when BP node adoption will increase)
-- Anchor contains txid field; so validation can be performed with just Bitcoin Core (no Electrum or BP node is required). This also speeded up validation performance significantly.
+- `Consignment` now has a version field, so in the future more space-saving 
+  variants can be created (like removing txid from anchors and using short 
+  universal bitcoin IDs when BP node adoption will increase)
+- Anchor contains txid field; so validation can be performed with just Bitcoin 
+  Core (no Electrum or BP node is required). This also speeded up validation 
+  performance significantly.
 
 ### Breaking changes
-- Change of `TransitionId` hash tag value (previously-generated transition ids will be invalid)
-- Change of `GenesisId`  hash tag value (previously-generated contract/assets ids will be invalid)
+- Change of `TransitionId` hash tag value (previously-generated transition ids 
+  will be invalid)
+- Change of `GenesisId`  hash tag value (previously-generated contract/assets 
+  ids will be invalid)
 - `TransitionId` type is replaced with `NodeId`
-- `NodeId` and `ContractId` are now equal by value; `ContractId` is `NodeId` wrapper
-- `ancestors()` method moved from `Transition` to `Node` trait; genesis returns an empty array
+- `NodeId` and `ContractId` are now equal by value; `ContractId` is `NodeId` 
+  wrapper
+- `ancestors()` method moved from `Transition` to `Node` trait; genesis returns 
+  an empty array
 - Consignment endpoints contain `NodeId` information

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "lnpbp"
-version = "0.1.0-rc.2"
+version = "0.1.0"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -518,7 +518,7 @@ dependencies = [
  "grin_secp256k1zkp",
  "inflate",
  "lazy_static",
- "lnpbp_derive",
+ "lnpbp_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniscript",
  "num-derive",
  "num-traits",
@@ -532,10 +532,21 @@ dependencies = [
 
 [[package]]
 name = "lnpbp_derive"
-version = "0.1.0-rc.2"
+version = "0.1.0"
 dependencies = [
  "amplify",
  "lnpbp",
+ "quote 1.0.7",
+ "syn 1.0.45",
+]
+
+[[package]]
+name = "lnpbp_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a7977c9c4d47f996d38b345dbc2c9cb34ce92948c375307242fa2531b5b951"
+dependencies = [
+ "amplify",
  "quote 1.0.7",
  "syn 1.0.45",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lnpbp"
-version = "0.1.0-rc.2"
+version = "0.1.0"
 license = "MIT"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "LNP/BP Core Library implementing LNPBP specifications & standards"
@@ -9,6 +9,7 @@ homepage = "https://github.com/LNP-BP"
 keywords = ["bitcoin", "lightning", "lnp-bp", "layer-3", "cryptography"]
 readme = "README.md"
 edition = "2018"
+exclude = [".github", "derive", "contrib"]
 
 [lib]
 name = "lnpbp"
@@ -35,7 +36,7 @@ crate-type = ["dylib", "rlib", "staticlib"]
 # -----------------------------------------
 amplify = { version = "~2.0.6", features = ["stringly_conversions"] }
 amplify_derive = "~2.0.6"
-lnpbp_derive = { path = "derive" }
+lnpbp_derive = "~0.1.0"
 # Dependencies on core rust-bitcoin ecosystem projects
 # ----------------------------------------------------
 bitcoin = { version = "~0.25.1", features = ["rand"] }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 ![Tests](https://github.com/LNP-BP/rust-lnpbp/workflows/Tests/badge.svg)
 ![Lints](https://github.com/LNP-BP/rust-lnpbp/workflows/Lints/badge.svg)
 [![codecov](https://codecov.io/gh/LNP-BP/rust-lnpbp/branch/master/graph/badge.svg)](https://codecov.io/gh/LNP-BP/rust-lnpbp)
+
+[![crates.io](https://meritbadge.herokuapp.com/lnpbp)](https://crates.io/crates/lnpbp)
+[![Docs](https://docs.rs/lnpbp/badge.svg)](https://docs.rs/lnpbp)
+[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 This is LNP/BP Core Library: a rust library implementing LNP/BP specifications 
@@ -115,6 +119,8 @@ brew cargo
 ```
 
 ### Clone and compile library
+
+Minimum supported rust compiler version (MSRV): 1.41.1
 
 ```shell script
 git clone https://github.com/lnp-bp/rust-lnpbp

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lnpbp_derive"
-version = "0.1.0-rc.2"
+version = "0.1.0"
 license = "MIT"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "LNP/BP Core Library derive macros"
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 quote = "~1.0.7"
 syn = "~1.0.31"
-amplify = "~2.0.0"
+amplify = "~2.0.6"
 
 [dev-dependencies]
 lnpbp = { path = ".." }


### PR DESCRIPTION
## Major changes since RC2
- Support for Rust stable and MSRV reduction to 1.41.1
- Custom forks for upstream bitcoin-related dependencies are changed onto the
  latest publicly-released versions

## Breaking changes since RC2
- Updated taproot-based hashed tag system (BIP-340) according to the most
  recent specs.
- RGB `Amount` renamed into `AtomicValue`
- RGB `amount` mod renamed into `value`
- RGB seal definitions and related structures are now `Copy` and returned by 
  value