### PR TITLE
add macos to the matrix strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,11 @@ env:
 
 jobs:
   features:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ ubuntu-latest, macos-latest ]
         feature:
           # Library components, one by one
           - rgb
@@ -37,62 +39,78 @@ jobs:
           - rgb,lnp,tokio,websockets,url,async,keygen
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
+      - name: Install linux dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y libzmq3-dev
+      - name: Install macos dependencies
+        if: matrix.os == 'macos-latest'
+        run: brew install pkg-config zmq
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - name: Feature ${{matrix.feature}}
+      - name: Feature ${{ matrix.feature }}
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --no-default-features --features=${{matrix.feature}}
-      - name: Defaults + ${{matrix.feature}}
+          args: --no-default-features --features=${{ matrix.feature }}
+      - name: Defaults + ${{ matrix.feature }}
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features=${{matrix.feature}}
+          args: --features=${{ matrix.feature }}
   tor:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ ubuntu-latest, macos-latest ]
         feature:
           - tor
           - tor,url
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
+      - name: Install linux dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y libzmq3-dev libssl-dev
+      - name: Install macos dependencies
+        if: matrix.os == 'macos-latest'
+        run: brew install pkg-config zmq
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - name: Feature ${{matrix.feature}}
+      - name: Feature ${{ matrix.feature }}
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --no-default-features --features=${{matrix.feature}}
-      - name: Defaults + ${{matrix.feature}}
+          args: --no-default-features --features=${{ matrix.feature }}
+      - name: Defaults + ${{ matrix.feature }}
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features=${{matrix.feature}}
+          args: --features=${{ matrix.feature }}
   toolchains:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ ubuntu-latest, macos-latest ]
         toolchain: [ nightly, beta, stable, 1.41.1 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
+      - name: Install linux dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y libzmq3-dev libssl-dev
-      - name: Install rust ${{matrix.toolchain}}
+      - name: Install macos dependencies
+        if: matrix.os == 'macos-latest'
+        run: brew install pkg-config zmq
+      - name: Install rust ${{ matrix.toolchain }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{matrix.toolchain}}
+          toolchain: ${{ matrix.toolchain }}
           override: true
       - name: All features
         uses: actions-rs/cargo@v1
@@ -100,11 +118,19 @@ jobs:
           command: build
           args: --workspace --all-targets --all-features
   dependency:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
+      - name: Install linux dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y libzmq3-dev libssl-dev
+      - name: Install macos dependencies
+        if: matrix.os == 'macos-latest'
+        run: brew install pkg-config zmq
       - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
 * don't fail fast so a failing arch doesn't cancel the remaining jobs
 * install dependencies based on matrix.os
 * uniform ${{ }} syntax usage