### PR TITLE
CI: add android + ios builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2019 ]
     steps:
       - uses: actions/checkout@v2
       - name: Install linux dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,3 +253,22 @@ jobs:
           export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
           export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-x86"
           cargo check --all-features --target=i686-linux-android
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Dependencies and targets
+        run: |
+          brew install zmq
+          rustup target add aarch64-apple-ios x86_64-apple-ios
+          cargo install cargo-lipo
+      - name: build
+        uses: actions-rs/cargo@v1
+        with:
+          command: lipo
+          args: --all-features --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NDK_VERSION: 20.1.5948944
+      ANDROID_CLI_ZIP: commandlinetools-linux-6858069_latest.zip
+      ANDROID_CLI_SHA256: 87f6dcf41d4e642e37ba03cb2e387a542aa0bd73cb689a9e7152aad40a6e7a08
     steps:
       - uses: actions/checkout@v2
       - name: Install rust
@@ -196,14 +198,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y libpcre3-dev libssl-dev
-          wget -nv https://freefr.dl.sourceforge.net/project/swig/swig/swig-4.0.1/swig-4.0.1.tar.gz
-          tar xf swig-4.0.1.tar.gz
-          cd swig-4.0.1 && ./configure && make -j4 && sudo make install
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --release
       - name: set environment variables
         run: |
           ANDROID_SDK_ROOT="$GITHUB_WORKSPACE/sdk"
@@ -213,11 +207,13 @@ jobs:
           echo "PATH=$PATH:$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_ENV
       - name: Install NDK
         run: |
-          wget -nv https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
-          unzip commandlinetools-linux-6609375_latest.zip
-          mkdir $ANDROID_SDK_ROOT && mv tools $ANDROID_SDK_ROOT/
-          yes 2>/dev/null | $ANDROID_SDK_ROOT/tools/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT \
-            "platform-tools" "build-tools;29.0.3" "platforms;android-29" "ndk;$NDK_VERSION" "cmake;3.10.2.4988404" |grep -v '\[='; true
+          wget -nv https://dl.google.com/android/repository/$ANDROID_CLI_ZIP
+          echo "$ANDROID_CLI_SHA256  $ANDROID_CLI_ZIP" > SHA256SUMS
+          sha256sum -c SHA256SUMS
+          unzip $ANDROID_CLI_ZIP
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools && mv cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/3.0
+          yes 2>/dev/null | $ANDROID_SDK_ROOT/cmdline-tools/3.0/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT \
+            "build-tools;29.0.3" "platforms;android-29" "ndk;$NDK_VERSION" |grep -v '\[='; true
       - name: Add rust targets
         run: |
           rustup target add aarch64-linux-android x86_64-linux-android armv7-linux-androideabi i686-linux-android
@@ -229,7 +225,7 @@ jobs:
           export CXX="aarch64-linux-android21-clang++"
           export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
           export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-arm64"
-          cargo check --all-features --release --target=aarch64-linux-android
+          cargo check --all-features --target=aarch64-linux-android
       - name: Build for x86_64-linux-android
         run: |
           export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android26-clang"
@@ -238,41 +234,4 @@ jobs:
           export CXX="x86_64-linux-android21-clang++"
           export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
           export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-x86_64"
-          cargo check --all-features --release --target=x86_64-linux-android
-      - name: Build for armv7-linux-androideabi
-        run: |
-          export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi26-clang"
-          export CC="armv7a-linux-androideabi21-clang"
-          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/arm-linux-androideabi"
-          export CXX="armv7a-linux-androideabi21-clang++"
-          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
-          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-arm -L$NDK_HOME/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a"
-          cargo check --all-features --release --target=armv7-linux-androideabi
-      - name: Build for i686-linux-android
-        run: |
-          export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android26-clang"
-          export CC="i686-linux-android21-clang"
-          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/i686-linux-android"
-          export CXX="i686-linux-android21-clang++"
-          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
-          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-x86"
-          cargo check --all-features --release --target=i686-linux-android
-  ios:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Dependencies and targets
-        run: |
-          brew install zmq
-          rustup target add aarch64-apple-ios x86_64-apple-ios
-          cargo install cargo-lipo
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: lipo
-          args: --all-features --release
+          cargo check --all-features --target=x86_64-linux-android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,3 +182,97 @@ jobs:
         run: |
           cd ..
           rm -rf dep_test
+  android:
+    runs-on: ubuntu-latest
+    env:
+      NDK_VERSION: 20.1.5948944
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y libpcre3-dev libssl-dev
+          wget -nv https://freefr.dl.sourceforge.net/project/swig/swig/swig-4.0.1/swig-4.0.1.tar.gz
+          tar xf swig-4.0.1.tar.gz
+          cd swig-4.0.1 && ./configure && make -j4 && sudo make install
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features --release
+      - name: set environment variables
+        run: |
+          ANDROID_SDK_ROOT="$GITHUB_WORKSPACE/sdk"
+          NDK_HOME="$ANDROID_SDK_ROOT/ndk/$NDK_VERSION"
+          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> $GITHUB_ENV
+          echo "NDK_HOME=$NDK_HOME" >> $GITHUB_ENV
+          echo "PATH=$PATH:$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_ENV
+      - name: Install NDK
+        run: |
+          wget -nv https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
+          unzip commandlinetools-linux-6609375_latest.zip
+          mkdir $ANDROID_SDK_ROOT && mv tools $ANDROID_SDK_ROOT/
+          yes 2>/dev/null | $ANDROID_SDK_ROOT/tools/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT \
+            "platform-tools" "build-tools;29.0.3" "platforms;android-29" "ndk;$NDK_VERSION" "cmake;3.10.2.4988404" |grep -v '\[='; true
+      - name: Add rust targets
+        run: |
+          rustup target add aarch64-linux-android x86_64-linux-android armv7-linux-androideabi i686-linux-android
+      - name: Build for aarch64-linux-android
+        run: |
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang"
+          export CC="aarch64-linux-android21-clang"
+          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/aarch64-linux-android"
+          export CXX="aarch64-linux-android21-clang++"
+          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
+          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-arm64"
+          cargo check --all-features --release --target=aarch64-linux-android
+      - name: Build for x86_64-linux-android
+        run: |
+          export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android26-clang"
+          export CC="x86_64-linux-android21-clang"
+          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/x86_64-linux-android"
+          export CXX="x86_64-linux-android21-clang++"
+          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
+          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-x86_64"
+          cargo check --all-features --release --target=x86_64-linux-android
+      - name: Build for armv7-linux-androideabi
+        run: |
+          export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi26-clang"
+          export CC="armv7a-linux-androideabi21-clang"
+          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/arm-linux-androideabi"
+          export CXX="armv7a-linux-androideabi21-clang++"
+          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
+          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-arm -L$NDK_HOME/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a"
+          cargo check --all-features --release --target=armv7-linux-androideabi
+      - name: Build for i686-linux-android
+        run: |
+          export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android26-clang"
+          export CC="i686-linux-android21-clang"
+          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/i686-linux-android"
+          export CXX="i686-linux-android21-clang++"
+          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
+          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-x86"
+          cargo check --all-features --release --target=i686-linux-android
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Dependencies and targets
+        run: |
+          brew install zmq
+          rustup target add aarch64-apple-ios x86_64-apple-ios
+          cargo install cargo-lipo
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: lipo
+          args: --all-features --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,3 +235,21 @@ jobs:
           export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
           export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-x86_64"
           cargo check --all-features --target=x86_64-linux-android
+      - name: Build for armv7-linux-androideabi
+        run: |
+          export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi26-clang"
+          export CC="armv7a-linux-androideabi21-clang"
+          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/arm-linux-androideabi"
+          export CXX="armv7a-linux-androideabi21-clang++"
+          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
+          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-arm -L$NDK_HOME/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a"
+          cargo check --all-features --target=armv7-linux-androideabi
+      - name: Build for i686-linux-android
+        run: |
+          export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android26-clang"
+          export CC="i686-linux-android21-clang"
+          export CFLAGS="--sysroot=$NDK_HOME/sysroot -I$NDK_HOME/sysroot/usr/include -I$NDK_HOME/sysroot/usr/include/i686-linux-android"
+          export CXX="i686-linux-android21-clang++"
+          export CXXFLAGS="$CFLAGS -nostdlib++ -I$NDK_HOME/sources/cxx-stl/llvm-libc++/include"
+          export LDFLAGS="--sysroot=$NDK_HOME/platforms/android-21/arch-x86"
+          cargo check --all-features --target=i686-linux-android

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
+checksum = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
 dependencies = [
  "cc",
 ]
@@ -814,6 +814,7 @@ dependencies = [
  "tokio",
  "torut",
  "url",
+ "zeromq-src 0.1.10+4.3.2 (git+https://github.com/LNP-BP/zeromq-src-rs?branch=fix/cmake)",
  "zmq",
 ]
 
@@ -2073,6 +2074,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeromq-src"
+version = "0.1.10+4.3.2"
+source = "git+https://github.com/LNP-BP/zeromq-src-rs?branch=fix/cmake#e95a4e68136a6897d61c936622933bf259ebdd7f"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "zmq"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,5 +2101,5 @@ checksum = "d33a2c51dde24d5b451a2ed4b488266df221a5eaee2ee519933dc46b9a9b3648"
 dependencies = [
  "libc",
  "metadeps",
- "zeromq-src",
+ "zeromq-src 0.1.10+4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "miniscript",
  "num-derive",
  "num-traits 0.2.14",
+ "openssl",
  "serde 1.0.117",
  "serde_with",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,16 +129,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aefc9be9f17185f4ebccae6575d342063f775924d57df0000edb1880c0fb7095"
 dependencies = [
  "bech32",
- "bitcoin_hashes 0.9.4",
- "secp256k1 0.19.0",
+ "bitcoin_hashes",
+ "secp256k1",
  "serde 1.0.117",
 ]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d62f341cef9cd9e77793ec8f1db3fc9ce2e4d57e982c8fe697a2c16af3b6"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -205,9 +199,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.41"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cfg-if"
@@ -309,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
+checksum = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
 dependencies = [
  "cc",
 ]
@@ -737,13 +731,12 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 [[package]]
 name = "lightning-invoice"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a8e3f3dcb1bf88550e6d2cc2b831779f8f4f7b2462573c2be0a1b28a59e82"
+source = "git+https://github.com/LNP-BP/rust-lightning-invoice?tag=lnpbp-v0.1.0-beta-4#979dce954315a386528fd1ddbde1a27fa89f00c1"
 dependencies = [
  "bech32",
- "bitcoin_hashes 0.7.6",
+ "bitcoin_hashes",
  "num-traits 0.2.14",
- "secp256k1 0.17.2",
+ "secp256k1",
 ]
 
 [[package]]
@@ -773,7 +766,7 @@ dependencies = [
  "async-trait",
  "bech32",
  "bitcoin",
- "bitcoin_hashes 0.9.4",
+ "bitcoin_hashes",
  "chacha20poly1305",
  "chrono",
  "deflate",
@@ -816,6 +809,7 @@ dependencies = [
  "miniscript",
  "num-derive",
  "num-traits 0.2.14",
+ "openssl",
  "serde 1.0.117",
  "serde_with",
  "tokio",
@@ -1442,31 +1436,13 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "secp256k1"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
-dependencies = [
- "secp256k1-sys 0.1.2",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
 dependencies = [
  "rand 0.6.5",
- "secp256k1-sys 0.3.0",
+ "secp256k1-sys",
  "serde 1.0.117",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2082,8 +2058,7 @@ dependencies = [
 [[package]]
 name = "zeromq-src"
 version = "0.1.10+4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9133d366817fcffe22e4356043ba187ae122ec5db63d7ce73d1e6a18efa2f1"
+source = "git+https://github.com/LNP-BP/zeromq-src-rs?branch=fix/cmake#e95a4e68136a6897d61c936622933bf259ebdd7f"
 dependencies = [
  "cmake",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,10 +129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aefc9be9f17185f4ebccae6575d342063f775924d57df0000edb1880c0fb7095"
 dependencies = [
  "bech32",
- "bitcoin_hashes",
- "secp256k1",
+ "bitcoin_hashes 0.9.4",
+ "secp256k1 0.19.0",
  "serde 1.0.117",
 ]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d62f341cef9cd9e77793ec8f1db3fc9ce2e4d57e982c8fe697a2c16af3b6"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -199,9 +205,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 
 [[package]]
 name = "cfg-if"
@@ -303,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
+checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
 dependencies = [
  "cc",
 ]
@@ -731,12 +737,13 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 [[package]]
 name = "lightning-invoice"
 version = "0.3.0"
-source = "git+https://github.com/LNP-BP/rust-lightning-invoice?tag=lnpbp-v0.1.0-beta-4#979dce954315a386528fd1ddbde1a27fa89f00c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0a8e3f3dcb1bf88550e6d2cc2b831779f8f4f7b2462573c2be0a1b28a59e82"
 dependencies = [
  "bech32",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.7.6",
  "num-traits 0.2.14",
- "secp256k1",
+ "secp256k1 0.17.2",
 ]
 
 [[package]]
@@ -766,7 +773,7 @@ dependencies = [
  "async-trait",
  "bech32",
  "bitcoin",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.9.4",
  "chacha20poly1305",
  "chrono",
  "deflate",
@@ -809,7 +816,6 @@ dependencies = [
  "miniscript",
  "num-derive",
  "num-traits 0.2.14",
- "openssl",
  "serde 1.0.117",
  "serde_with",
  "tokio",
@@ -1436,13 +1442,31 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "secp256k1"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
+dependencies = [
+ "secp256k1-sys 0.1.2",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
 dependencies = [
  "rand 0.6.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.3.0",
  "serde 1.0.117",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2058,7 +2082,8 @@ dependencies = [
 [[package]]
 name = "zeromq-src"
 version = "0.1.10+4.3.2"
-source = "git+https://github.com/LNP-BP/zeromq-src-rs?branch=fix/cmake#e95a4e68136a6897d61c936622933bf259ebdd7f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9133d366817fcffe22e4356043ba187ae122ec5db63d7ce73d1e6a18efa2f1"
 dependencies = [
  "cmake",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992c9ba9e4201debd030782f04d6315a037f4df0c517d336d0eeaa4586b2afd0"
+checksum = "3ba06653cdfce8bfa4faf2c7e5cee3f21adf1bcc1e80ee2e1dec8be764014b0d"
 dependencies = [
  "quote 1.0.7",
  "syn 1.0.48",
@@ -129,16 +129,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aefc9be9f17185f4ebccae6575d342063f775924d57df0000edb1880c0fb7095"
 dependencies = [
  "bech32",
- "bitcoin_hashes 0.9.4",
- "secp256k1 0.19.0",
+ "bitcoin_hashes",
+ "secp256k1",
  "serde 1.0.117",
 ]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d62f341cef9cd9e77793ec8f1db3fc9ce2e4d57e982c8fe697a2c16af3b6"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -205,9 +199,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.41"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 
 [[package]]
 name = "cfg-if"
@@ -543,9 +537,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-core"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
 name = "generic-array"
@@ -737,13 +731,12 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 [[package]]
 name = "lightning-invoice"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a8e3f3dcb1bf88550e6d2cc2b831779f8f4f7b2462573c2be0a1b28a59e82"
+source = "git+https://github.com/LNP-BP/rust-lightning-invoice?tag=lnpbp-v0.1.0-beta-4#979dce954315a386528fd1ddbde1a27fa89f00c1"
 dependencies = [
  "bech32",
- "bitcoin_hashes 0.7.6",
+ "bitcoin_hashes",
  "num-traits 0.2.14",
- "secp256k1 0.17.2",
+ "secp256k1",
 ]
 
 [[package]]
@@ -773,7 +766,7 @@ dependencies = [
  "async-trait",
  "bech32",
  "bitcoin",
- "bitcoin_hashes 0.9.4",
+ "bitcoin_hashes",
  "chacha20poly1305",
  "chrono",
  "deflate",
@@ -803,7 +796,7 @@ dependencies = [
  "async-trait",
  "bech32",
  "bitcoin",
- "bitcoin_hashes 0.9.4",
+ "bitcoin_hashes",
  "chacha20poly1305",
  "chrono",
  "deflate",
@@ -1105,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "parse_arg"
@@ -1117,9 +1110,9 @@ checksum = "14248cc8eced350e20122a291613de29e4fa129ba2731818c4cdbb44fccd3e55"
 
 [[package]]
 name = "paste"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7ae1a2180ed02ddfdb5ab70c70d596a26dd642e097bb6fe78b1bde8588ed97"
+checksum = "7151b083b0664ed58ed669fcdd92f01c3d2fdbf10af4931a301474950b52bfa9"
 
 [[package]]
 name = "percent-encoding"
@@ -1442,31 +1435,13 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "secp256k1"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
-dependencies = [
- "secp256k1-sys 0.1.2",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
 dependencies = [
  "rand 0.6.5",
- "secp256k1-sys 0.3.0",
+ "secp256k1-sys",
  "serde 1.0.117",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1664,9 +1639,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1800,9 +1775,18 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -1830,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1893,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ crate-type = ["dylib", "rlib", "staticlib"]
 # equivalence requirements (with '=' sign) since even dependencies patching will
 # not introduce risk of breaking the consensus and even security updates must
 # be done manually after through testing
+
 [dependencies]
 # Dependencies on other LNP/BP repositories
 # -----------------------------------------
@@ -43,7 +44,7 @@ bitcoin = { version = "~0.25.1", features = ["rand"] }
 bitcoin_hashes = "~0.9.3" # we need macro from here
 miniscript = "~3.0.0"
 bech32 = "~0.7.2"
-lightning-invoice = { version = "~0.3.0", optional = true }
+lightning-invoice = { git = "https://github.com/LNP-BP/rust-lightning-invoice", tag = "lnpbp-v0.1.0-beta-4", optional = true  }
 chacha20poly1305 = "~0.7.0"
 #   Used only as a part of RGB for encoding Ed25519 key data (for instance as
 #   a part of Tor address)
@@ -92,13 +93,15 @@ torut = { version = "~0.1.6", features = ["v2", "v3"] }
 miniscript = { version = "~3.0.0", features = ["compiler"] }
 bitcoin = { version = "~0.25.0", features = ["rand"] }
 
+[patch.crates-io]
+# Remove this once https://github.com/jean-airoldie/zeromq-src-rs/pull/15 got merged
+zeromq-src = { git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
+
 [target.'cfg(target_os="android")'.dependencies]
 zmq = { version = "~0.9", features = ["vendored"] }
 
-[target.'cfg(target_os="android")'.patch.crates-io]
-# Use this for Android builds
-# Remove this once https://github.com/jean-airoldie/zeromq-src-rs/pull/15 got merged
-zeromq-src = { git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
+[target.'cfg(target_os="ios")'.dependencies]
+openssl = { version = "^0.10", features = ["vendored"] }
 
 # Features
 # ========

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,9 @@ zmq = { version = "~0.9", features = ["vendored"] }
 [target.'cfg(target_os="ios")'.dependencies]
 zeromq-src = { git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
 
+[target.'cfg(target_os="windows")'.dependencies]
+openssl = { features = ["vendored"] }
+
 [patch.crates-io]
 # required to build on 32-bit architectures
 # see also https://github.com/LNP-BP/rgb-node/issues/4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,14 +87,19 @@ num-derive = "~0.3.0"
 async-trait = { version = "~0.1.30", optional = true }
 torut = { version = "~0.1.6", features = ["v2", "v3"] }
 
+[target.'cfg(target_os="android")'.dependencies]
+zmq = { version = "~0.9", features = ["vendored"] }
+
+[patch.crates-io]
+# required to build on 32-bit architectures
+# see also https://github.com/LNP-BP/rgb-node/issues/4
+lightning-invoice = { git = "https://github.com/LNP-BP/rust-lightning-invoice", tag = "lnpbp-v0.1.0-beta-4", optional = true  }
+
 [dev-dependencies]
 # <https://github.com/LNP-BP/LNPBPs/blob/master/lnpbp-0002.md#deterministic-public-key-extraction-from-bitcoin-script>
 # We fix version of miniscript as required by LNPBP-2 specification
 miniscript = { version = "~3.0.0", features = ["compiler"] }
 bitcoin = { version = "~0.25.0", features = ["rand"] }
-
-[target.'cfg(target_os="android")'.dependencies]
-zmq = { version = "~0.9", features = ["vendored"] }
 
 # Features
 # ========

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ crate-type = ["dylib", "rlib", "staticlib"]
 # equivalence requirements (with '=' sign) since even dependencies patching will
 # not introduce risk of breaking the consensus and even security updates must
 # be done manually after through testing
-
 [dependencies]
 # Dependencies on other LNP/BP repositories
 # -----------------------------------------
@@ -44,7 +43,8 @@ bitcoin = { version = "~0.25.1", features = ["rand"] }
 bitcoin_hashes = "~0.9.3" # we need macro from here
 miniscript = "~3.0.0"
 bech32 = "~0.7.2"
-lightning-invoice = { git = "https://github.com/LNP-BP/rust-lightning-invoice", tag = "lnpbp-v0.1.0-beta-4", optional = true  }
+lightning-invoice = { version = "~0.3.0", optional = true }
+
 chacha20poly1305 = "~0.7.0"
 #   Used only as a part of RGB for encoding Ed25519 key data (for instance as
 #   a part of Tor address)
@@ -93,15 +93,8 @@ torut = { version = "~0.1.6", features = ["v2", "v3"] }
 miniscript = { version = "~3.0.0", features = ["compiler"] }
 bitcoin = { version = "~0.25.0", features = ["rand"] }
 
-[patch.crates-io]
-# Remove this once https://github.com/jean-airoldie/zeromq-src-rs/pull/15 got merged
-zeromq-src = { git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
-
 [target.'cfg(target_os="android")'.dependencies]
 zmq = { version = "~0.9", features = ["vendored"] }
-
-[target.'cfg(target_os="ios")'.dependencies]
-openssl = { version = "^0.10", features = ["vendored"] }
 
 # Features
 # ========

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ torut = { version = "~0.1.6", features = ["v2", "v3"] }
 [target.'cfg(target_os="android")'.dependencies]
 zmq = { version = "~0.9", features = ["vendored"] }
 
+[target.'cfg(target_os="ios")'.dependencies]
+zeromq-src = { git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
+
 [patch.crates-io]
 # required to build on 32-bit architectures
 # see also https://github.com/LNP-BP/rgb-node/issues/4

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The library is based on other projects:
 
 On Debian, run
 ```shell script
-sudo apt-get install cargo libssl-dev libzmq3-dev pkg-cofig
+sudo apt-get install cargo libssl-dev libzmq3-dev pkg-config
 ```
 
 On Mac OS, run


### PR DESCRIPTION
some points that might require special attention during review:
- `zeromq-src` from https://github.com/LNP-BP/zeromq-src-rs is now applied globally instead of just for android
- `lightning-invoice` is now fetched from https://github.com/LNP-BP/rust-lightning-invoice to avoid the same error as in https://github.com/LNP-BP/rgb-node/issues/4
- `openssl` is now vendored for ios
- these new jobs use `cargo check` instead of `cargo build`, as in `467ba2a80e945c3e4915a43b3ee82bde08b6607b`