### PR TITLE
CI: add crate publication workflow

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -1,0 +1,19 @@
+name: Publication
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publication:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - run: |
+          (cd derive && cargo publish --all-features)
+          cargo publish --all-features


### PR DESCRIPTION
refers to #142 

from the repo's github page go to `Settings -> Secrets` and add a new secret named `CRATES_IO_TOKEN` and, as its value, add an access token from your crates.io account (the one you use for `cargo login <access_token>`)