### PR TITLE
Expose rgb::stash::ExtensionData

### DIFF
--- a/src/rgb/mod.rs
+++ b/src/rgb/mod.rs
@@ -36,8 +36,8 @@ pub mod prelude {
         SimplicityScript, TransitionAbi, TransitionAction,
     };
     pub use stash::{
-        Anchor, AnchorId, Consignment, ConsignmentEndpoints, Disclosure, Stash,
-        TransitionData, PSBT_OUT_PUBKEY, PSBT_OUT_TWEAK,
+        Anchor, AnchorId, Consignment, ConsignmentEndpoints, Disclosure,
+        ExtensionData, Stash, TransitionData, PSBT_OUT_PUBKEY, PSBT_OUT_TWEAK,
     };
     pub use validation::{Validator, Validity};
     pub use vm::VirtualMachine;

--- a/src/rgb/stash/mod.rs
+++ b/src/rgb/stash/mod.rs
@@ -17,6 +17,8 @@ mod disclosure;
 mod stash;
 
 pub use anchor::{Anchor, AnchorId, PSBT_OUT_PUBKEY, PSBT_OUT_TWEAK};
-pub use consignment::{Consignment, ConsignmentEndpoints, TransitionData};
+pub use consignment::{
+    Consignment, ConsignmentEndpoints, ExtensionData, TransitionData,
+};
 pub use disclosure::Disclosure;
 pub use stash::Stash;


### PR DESCRIPTION
in order to expose `validate` (as requested in LNP-BP/rgb-node#97) the `ExtensionData` type must be exposed (used to create the `Consignment` object)