### PR TITLE
Add serde (de)serialization of Consignment

### DIFF
--- a/src/bp/dbc/spk.rs
+++ b/src/bp/dbc/spk.rs
@@ -58,6 +58,11 @@ pub enum ScriptEncodeMethod {
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]
 #[display(doc_comments)]
 #[non_exhaustive]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum ScriptEncodeData {
     /// Public key. Since we keep the original public key as a part of a proof,
     /// and value of the tweaked key can be reconstructed with DBC source data

--- a/src/bp/dbc/types.rs
+++ b/src/bp/dbc/types.rs
@@ -36,6 +36,11 @@ pub trait Container: Sized {
 )]
 #[lnpbp_crate(crate)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Proof {
     pub pubkey: secp256k1::PublicKey,
     pub source: ScriptEncodeData,

--- a/src/bp/scripts/types.rs
+++ b/src/bp/scripts/types.rs
@@ -130,6 +130,11 @@ use crate::strict_encoding;
 )]
 #[display("{0}", alt = "{_0:x}")]
 #[wrapper(LowerHex, UpperHex)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct LockScript(Script);
 
 impl strict_encoding::Strategy for LockScript {

--- a/src/rgb/stash/anchor.rs
+++ b/src/rgb/stash/anchor.rs
@@ -82,6 +82,11 @@ pub enum Error {
 #[derive(Clone, PartialEq, Eq, Debug, StrictEncode, StrictDecode)]
 #[cfg_attr(test, derive(Default))]
 #[lnpbp_crate(crate)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Anchor {
     pub txid: Txid,
     pub commitment: MultimsgCommitment,

--- a/src/rgb/stash/consignment.rs
+++ b/src/rgb/stash/consignment.rs
@@ -31,6 +31,11 @@ pub const RGB_CONSIGNMENT_VERSION: u16 = 0;
 #[derive(Clone, PartialEq, Eq, Debug, Display, StrictEncode, StrictDecode)]
 #[lnpbp_crate(crate)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Consignment {
     version: u16,
     pub genesis: Genesis,

--- a/src/standards/lnpbp4.rs
+++ b/src/standards/lnpbp4.rs
@@ -41,6 +41,11 @@ pub struct TooManyMessagesError;
 )]
 #[lnpbp_crate(crate)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct MultimsgCommitmentItem {
     pub protocol: Option<sha256::Hash>,
     pub commitment: Lnpbp4Hash,
@@ -70,6 +75,11 @@ impl MultimsgCommitmentItem {
 )]
 #[lnpbp_crate(crate)]
 #[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct MultimsgCommitment {
     pub commitments: Vec<MultimsgCommitmentItem>,
     pub entropy: Option<u64>,


### PR DESCRIPTION
this PR is needed in order to do the task

> Add validate and accept functions to support acceptance of transfers

defined in LNP-BP/rgb-sdk#2