### PR TITLE
add g++ and cmake to Debian requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The library is based on other projects:
 
 On Debian, run
 ```shell script
-sudo apt-get install cargo libssl-dev libzmq3-dev pkg-config
+sudo apt-get install cargo libssl-dev libzmq3-dev pkg-config g++ cmake
 ```
 
 On Mac OS, run


### PR DESCRIPTION
the `cargo build` was failing on a clean Debian, I tested it on a `debian:buster` docker image.
I added the missed dependencies.