### PR TITLE
add publish testing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y libzmq3-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y libzmq3-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y libzmq3-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev
       - name: Install macos dependencies
         if: startsWith(matrix.os, 'macos')
         run: brew install pkg-config zmq
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y libzmq3-dev libssl-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev libssl-dev
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y libzmq3-dev libssl-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev libssl-dev
       - name: Install rust ${{ matrix.toolchain }}
         uses: actions-rs/toolchain@v1
         with:
@@ -162,7 +162,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y libzmq3-dev libssl-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev libssl-dev
       - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:
@@ -197,6 +197,7 @@ jobs:
           override: true
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libpcre3-dev libssl-dev
       - name: set environment variables
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y libzmq3-dev libssl-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev libssl-dev
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y libzmq3-dev libssl-dev
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev libssl-dev
       - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 
 [[package]]
 name = "cfg-if"
@@ -797,6 +797,7 @@ dependencies = [
  "bech32",
  "bitcoin",
  "bitcoin_hashes",
+ "cc",
  "chacha20poly1305",
  "chrono",
  "deflate",
@@ -812,6 +813,7 @@ dependencies = [
  "openssl",
  "serde 1.0.117",
  "serde_with",
+ "socket2",
  "tokio",
  "torut",
  "url",
@@ -1641,9 +1643,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1739,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -1777,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1792,9 +1794,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes",
  "fnv",
@@ -1879,18 +1881,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ zmq = { version = "~0.9", features = ["vendored"] }
 zeromq-src = { version = "~0.1", git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-openssl = { features = ["vendored"] }
+openssl = { version = "~0.10", features = ["vendored"] }
 
 [patch.crates-io]
 # required to build on 32-bit architectures

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ torut = { version = "~0.1.6", features = ["v2", "v3"] }
 zmq = { version = "~0.9", features = ["vendored"] }
 
 [target.'cfg(target_os="ios")'.dependencies]
-zeromq-src = { git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
+zeromq-src = { version = "~0.1", git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }
 
 [target.'cfg(target_os="windows")'.dependencies]
 openssl = { features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ async-trait = { version = "~0.1.30", optional = true }
 torut = { version = "~0.1.6", features = ["v2", "v3"] }
 
 [target.'cfg(target_os="android")'.dependencies]
+cc = { version = "=1.0.41" }
+socket2 = { version = "=0.3.15" }
 zmq = { version = "~0.9", features = ["vendored"] }
 
 [target.'cfg(target_os="ios")'.dependencies]


### PR DESCRIPTION
this PR adds a "Publish" workflow to catch early issues that may arise at publishing time

as briefly discussed, if this introduces a significant slowdown in day to day operations, we can wait to merge this or devise a new scheme to handle code contributions (and contributors) that require the least friction

notes:
- `cargo publish` is called with the `--dry-run` option to skip the real publishing
- a first fix that's been found by the workflow is included (`error: all dependencies must have a version specified when publishing.`)