### PR TITLE
add publication workflow using cargo workspaces

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -1,0 +1,55 @@
+name: Publication
+
+on:
+  push:
+    branches:
+      - release
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publication:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: install cargo-workspaces
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-workspaces
+      - name: publication
+        env:
+          COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
+          CRATES_IO_TOKEN: "${{ secrets.CRATES_IO_TOKEN }}"
+        run: |
+          # version update
+          ERR_MSG="'[...] new version <version>' expected in a commit message line"
+          export VERSION="$(echo $COMMIT_MESSAGE | awk '/new version/ {print $NF}')"
+          [ -n "$VERSION" ] || (echo "unable to determine version, $ERR_MSG" && exit 1)
+          echo "updating crate versions..."
+          cargo workspaces version -y --force '*' --no-git-commit --exact custom "$VERSION"
+          echo "creating publishing commit and tag..."
+          git config --global user.email "runner@gha.local"
+          git config --global user.name "Github Action"
+          git commit -am "publish version $VERSION"
+          git tag -a -m "v$VERSION update" "v$VERSION"
+          # publishing
+          echo "publishing crates..."
+          # we'll be able to use "cargo ws publish --token" from 0.2.16+
+          cargo login "$CRATES_IO_TOKEN"
+          cargo workspaces publish --from-git --skip-published
+          # update remote branches
+          echo "pushing changes to release branch..."
+          git push origin release:release
+          echo "pushing changes to master branch..."
+          git fetch --unshallow origin master
+          git checkout master
+          git merge "v$VERSION"
+          git push origin master:master
+          echo "done"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["dylib", "rlib", "staticlib"]
 # -----------------------------------------
 amplify = { version = "~2.3.1", features = ["stringly_conversions"] }
 amplify_derive = "~2.3.0"
-lnpbp_derive = "=0.2.0-rc.1+2"
+lnpbp_derive = { path = "derive", version = "=0.2.0-rc.1+2" }
 # Dependencies on core rust-bitcoin ecosystem projects
 # ----------------------------------------------------
 bitcoin = { version = "~0.25.1", features = ["rand"] }

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 # LNP/BP libraries
 amplify = "~2.3.1"
 amplify_derive = "~2.3.0"
-lnpbp = "=0.2.0-rc.1+2"
-lnpbp_derive = "=0.2.0-rc.1+2"
+lnpbp = { path = "../", version = "=0.2.0-rc.1+2" }
+lnpbp_derive = { path = "../derive", version = "=0.2.0-rc.1+2" }
 # Serialization & parsing
 serde_crate = { package = "serde", version = "~1.0.106", features = ["derive"], optional = true }
 serde_with = { version = "~1.5.1", optional = true, features = ["hex"] }


### PR DESCRIPTION
resuming from PR #143, here is a proposal to handle publishing via `cargo workspaces`

### requirements

- the `cargo login` token configured in github as a secret named `CRATES_IO_TOKEN`

### proposed release steps

- prepare the `master` branch for the release
- create or update the `release` branch to be aligned with `master`
- create a release commit (typically with the updated changelog) on the `release` branch, including a line that ends with "`new version <version>`" in the commit message (see example below)
- push the release commit, triggering the workflow

### what the workflow will do

- checkout the `release` branch
- get the new version from the commit message (e.g. `0.2.0-rc.2` in the example)
- update crate versions and inter-dependencies (using _exact_ versions for dependencies, with the `=` symbol)
- commit and tag the version change, the tag will be prefixed with a `v` (e.g. `v0.2.0-rc.2`)
- publish the packages to `crates.io` (using the token provided via github secrets)
- merge and push the new commits to the `master` branch

### other considerations
- I started trying to trigger the workflow with a tag (e.g. `rel0.2.0-rc.2`) but it didn't work since a tag-triggered workflow can't push a new tag (e.g. `v0.2.0-rc.2`), as it's forbidden by github (to avoid workflow loops AFAIK)
- I also re-wrote the inter-dependencies in the form `<package> = { path = "<path>", version = "=<version>" }` to avoid `cargo ws version` errors on `lnpbp_derive` of the kind `failed to select a version for the requirement`
- the `cargo ws version` command produces some other errors of the same kind (see example below) but I left those as they are for now, since they appear related to the tokio/socket2 dependency issue (weren't there some days ago) and don't make `cargo ws version` or `cargo ws publish` fail

### examples

commit message:
```
update changelog

 * new version 0.2.0-rc.2
```

`cargo ws version` error:
```
error: failed to select a version for the requirement `socket2 = "=0.3.15"`
candidate versions found which didn't match: 0.3.17, 0.3.16, 0.2.4, ...
location searched: crates.io index
required by package `lnpbp v0.2.0+2 (/home/dieeasy/git/lnp-bp/rust-lnpbp)`
```

### conclusions

there surely are many improvements than can be done, like more and stricter checks to avoid release issues, but it should be a good starting point

let's discuss and optionally wait for a fix to #159 (and then document the final release procedure before merging)