### PR TITLE
[WIP] Implementing HTLC extension modification to TxGraph

### DIFF
--- a/derive/src/lnp_api.rs
+++ b/derive/src/lnp_api.rs
@@ -272,15 +272,9 @@ impl EncodingSrategy {
 
     pub fn encode_fn(&self) -> TokenStream2 {
         match self {
-            Self::Strict => {
-                quote!(strict_encode)
-            }
-            Self::Bitcoin => {
-                quote!(consensus_encode)
-            }
-            Self::Lightning => {
-                quote!(lightning_encode)
-            }
+            Self::Strict => quote!(strict_encode),
+            Self::Bitcoin => quote!(consensus_encode),
+            Self::Lightning => quote!(lightning_encode),
         }
     }
 

--- a/src/bp/dbc/txout.rs
+++ b/src/bp/dbc/txout.rs
@@ -87,9 +87,7 @@ impl Container for TxoutContainer {
 }
 
 /// [bitcoin::TxOut] containing LNPBP-2 commitment
-#[derive(
-    Wrapper, Clone, PartialEq, Eq, Hash, Default, Debug, Display, From,
-)]
+#[derive(Wrapper, Clone, PartialEq, Eq, Hash, Default, Debug, Display, From)]
 #[display(Debug)]
 pub struct TxoutCommitment(TxOut);
 

--- a/src/bp/scripts/types.rs
+++ b/src/bp/scripts/types.rs
@@ -110,10 +110,10 @@ use bitcoin::{
 use crate::bp::{Chain, CompactDescriptor};
 use crate::strict_encoding;
 
-/// Script which knowledge is required for spending some specific transaction
+/// Script whose knowledge is required for spending some specific transaction
 /// output. This is the deepest nested version of Bitcoin script containing no
 /// hashes of other scripts, including P2SH redeemScript hashes or
-/// witnessProgram (hash or witness script), or public keys
+/// witnessProgram (hash or witness script), or public key hashes
 #[derive(
     Wrapper,
     Clone,

--- a/src/lnp/application/channel.rs
+++ b/src/lnp/application/channel.rs
@@ -205,7 +205,7 @@ pub struct TxGraph {
     pub cmt_locktime: u32,
     pub cmt_sequence: u32,
     pub cmt_outs: Vec<TxOut>,
-    graph: BTreeMap<u16, BTreeMap<u64, Psbt>>,
+    pub graph: BTreeMap<u16, BTreeMap<u64, Psbt>>,
 }
 
 impl TxGraph {

--- a/src/lnp/application/channel.rs
+++ b/src/lnp/application/channel.rs
@@ -205,7 +205,7 @@ pub struct TxGraph {
     pub cmt_locktime: u32,
     pub cmt_sequence: u32,
     pub cmt_outs: Vec<TxOut>,
-    pub graph: BTreeMap<u16, BTreeMap<u64, Psbt>>,
+    graph: BTreeMap<u16, BTreeMap<u64, Psbt>>,
 }
 
 impl TxGraph {
@@ -227,6 +227,22 @@ impl TxGraph {
         self.graph
             .get_mut(&role.into())
             .and_then(|v| v.get_mut(&index.into()))
+    }
+
+    pub fn insert_tx<R, I>(
+        &mut self,
+        role: R,
+        index: I,
+        psbt: Psbt,
+    ) -> Option<Psbt>
+    where
+        R: TxRole,
+        I: TxIndex,
+    {
+        self.graph
+            .entry(role.into())
+            .or_insert(empty!())
+            .insert(index.into(), psbt)
     }
 
     pub fn len(&self) -> usize {

--- a/src/lnp/application/channel.rs
+++ b/src/lnp/application/channel.rs
@@ -40,6 +40,9 @@ use super::Messages;
 pub enum Error {
     /// Extension-specific error: {0}
     Extension(String),
+
+    // HTLC Extension Errors
+    HTLC(String),
 }
 
 /// Marker trait for any data that can be used as a part of the channel state
@@ -201,6 +204,8 @@ pub struct TxGraph {
     funding_threshold: u8,
     funding_tx: Psbt,
     funding_outpoint: OutPoint,
+    commitment_outpoint: OutPoint, /* We should have a commitment outpoint
+                                    * for HTLC success and timeout Tx */
     pub cmt_version: i32,
     pub cmt_locktime: u32,
     pub cmt_sequence: u32,
@@ -249,6 +254,16 @@ impl TxGraph {
         self.graph
             .iter()
             .fold(0usize, |sum, (_, map)| sum + map.len())
+    }
+
+    pub fn last_index<R>(&self, role: R) -> usize
+    where
+        R: TxRole,
+    {
+        match self.graph.get(&role.into()) {
+            Some(map) => map.len(),
+            None => 0usize,
+        }
     }
 
     pub fn render(&self) -> Vec<Psbt> {

--- a/src/lnp/application/extension.rs
+++ b/src/lnp/application/extension.rs
@@ -46,7 +46,7 @@ pub trait Extension {
 
     fn identity(&self) -> Self::Identity;
 
-    /// Updates extension state from the data takend from the message received
+    /// Updates extension state from the data taken from the message received
     /// from the remote peer
     fn update_from_peer(
         &mut self,

--- a/src/lnp/application/payment/mod.rs
+++ b/src/lnp/application/payment/mod.rs
@@ -21,7 +21,7 @@ mod modifiers;
 
 pub use invoice::Invoice;
 pub use types::{
-    AssetsBalance, ChannelId, ExtensionId, Lifecycle, TempChannelId,
+    AssetsBalance, ChannelId, ExtensionId, Lifecycle, TempChannelId, TxType,
 };
 
 pub use constructors::{bolt3, eltoo, taproot, Bolt3};

--- a/src/lnp/application/payment/types.rs
+++ b/src/lnp/application/payment/types.rs
@@ -22,8 +22,8 @@ use bitcoin::OutPoint;
 
 use crate::bp::chain::AssetId;
 use crate::bp::Slice32;
-use crate::lnp::application::extension;
-use crate::strict_encoding::{self, strict_deserialize, strict_serialize};
+use crate::lnp::application::{channel, extension};
+use crate::strict_encoding::{self, strict_decode, strict_encode};
 
 /// Shorthand for representing asset - amount pairs
 pub type AssetsBalance = BTreeMap<AssetId, u64>;
@@ -88,6 +88,50 @@ impl TryFrom<u16> for ExtensionId {
 }
 
 impl extension::Nomenclature for ExtensionId {}
+
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+    Display,
+    StrictEncode,
+    StrictDecode,
+)]
+#[lnpbp_crate(crate)]
+#[display(Debug)]
+#[non_exhaustive]
+pub enum TxType {
+    HtlcSuccess,
+    HtlcTimeout,
+    Unknown(u16),
+}
+
+impl From<TxType> for u16 {
+    fn from(ty: TxType) -> Self {
+        match ty {
+            TxType::HtlcSuccess => 0x0,
+            TxType::HtlcTimeout => 0x1,
+            TxType::Unknown(x) => x,
+        }
+    }
+}
+
+impl From<u16> for TxType {
+    fn from(ty: u16) -> Self {
+        match ty {
+            0x00 => TxType::HtlcSuccess,
+            0x01 => TxType::HtlcTimeout,
+            x => TxType::Unknown(x),
+        }
+    }
+}
+
+impl channel::TxRole for TxType {}
 
 #[cfg_attr(feature = "serde", serde_as(as = "DisplayFromStr"))]
 #[cfg_attr(


### PR DESCRIPTION
This is a WIP on HTLC extension modification to the TXGraph structure. 

This is preliminary and for approach check. There are many rough edges. Instead of describing the issues here, I have added comments in the codebase referring to which discussions can be held here. 

There are many data that are required for constructing these HTLC transactions which are not there in the HTLC structure. I suppose the extension would then need to have access to global channel state variables in order to get that information. Suggestions over this would be helpful.

This might be also a good time to decide how these should be stored on the graph map inside TxGraph.
 
Note: for anchor outputs, we would need clear segregation Anchors, HTLCs, and payment outputs of a commitment Tx. There will be specific modifications on specific outputs. We should think of creating the TxGraph keeping that in mind.  