### PR TITLE
Improvement to client_side_validation crate (CommitEncode for vectors)

### DIFF
--- a/client_side_validation/src/client_side_validation.rs
+++ b/client_side_validation/src/client_side_validation.rs
@@ -125,6 +125,17 @@ pub mod commit_strategy {
         }
     }
 
+    // Marker trait for automatically implementing the CommitEncode trait
+    //  (with Merklization strategy) for a vector of that given type
+    pub trait VectorCommitEncode {}
+
+    impl<T> CommitEncodeWithStrategy for Vec<T>
+    where
+        T: VectorCommitEncode
+    {
+        type Strategy = commit_strategy::Merklization;
+    }
+
     impl CommitEncodeWithStrategy for usize {
         type Strategy = UsingStrict;
     }


### PR DESCRIPTION
This adds a standard implementation of the CommitEncode trait (with Merklization strategy) for vectors of a designated type. To activate the implementation, one just needs to implement the new VectorCommitEncode trait marker for that type.

The motivation for this improvement was the need to implement the CommitEncode trait for the Assignments structure of the `rgb-core` crate, which essentially is a vector a complex type.