### PR TITLE
Improving commit encodings collection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,6 @@ dependencies = [
 [[package]]
 name = "lnpbp"
 version = "0.4.0-beta"
-source = "git+https://github.com/LNP-BP/rust-lnpbp#0ccced3445dd5ad76f76c436c00596a926aa3cad"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -727,6 +726,7 @@ dependencies = [
 [[package]]
 name = "lnpbp"
 version = "0.4.0-beta"
+source = "git+https://github.com/LNP-BP/rust-lnpbp#0ccced3445dd5ad76f76c436c00596a926aa3cad"
 dependencies = [
  "amplify",
  "amplify_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,9 +198,9 @@ checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -225,7 +242,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -238,8 +255,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "client_side_validation"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfd8dba1ad3d1958eac41d2675f6802606917e61daa312ea5b68fd2f075e934"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -251,8 +302,18 @@ dependencies = [
 [[package]]
 name = "client_side_validation"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfd8dba1ad3d1958eac41d2675f6802606917e61daa312ea5b68fd2f075e934"
+source = "git+https://github.com/LNP-BP/rust-lnpbp#ce914435ddf2089c9f903463d53d6ac79da7c34b"
+dependencies = [
+ "amplify",
+ "amplify_derive",
+ "bitcoin_hashes",
+ "grin_secp256k1zkp",
+ "strict_encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "client_side_validation"
+version = "0.4.0-beta"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -334,7 +395,7 @@ dependencies = [
  "ident_case",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "strsim",
+ "strsim 0.9.3",
  "syn 1.0.60",
 ]
 
@@ -376,12 +437,13 @@ dependencies = [
 [[package]]
 name = "descriptor-wallet"
 version = "0.4.0-beta"
-source = "git+https://github.com/LNP-BP/descriptor-wallet#c7478e3ce89b74a00341c25cf044cbffeb269145"
+source = "git+https://github.com/LNP-BP/descriptor-wallet#e39f6f3a4d278d90432e12015c203ccba998b5bf"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bitcoin",
  "chrono",
+ "electrum-client",
  "lazy_static",
  "lightning_encoding",
  "miniscript",
@@ -440,6 +502,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "electrum-client"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21453800c95bb1aaa57490458c42d60c6277cb8a3e386030ec2381d5c2d4fa77"
+dependencies = [
+ "bitcoin",
+ "log",
+ "rustls",
+ "serde",
+ "serde_json",
+ "socks",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,9 +552,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -535,6 +613,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,13 +660,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+dependencies = [
+ "autocfg 1.0.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -633,6 +745,15 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "js-sys"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "keccak"
@@ -709,7 +830,7 @@ dependencies = [
  "bech32",
  "bitcoin",
  "bitcoin_hashes",
- "client_side_validation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "client_side_validation 0.3.0 (git+https://github.com/LNP-BP/rust-lnpbp)",
  "deflate",
  "descriptor-wallet",
  "inflate",
@@ -726,7 +847,7 @@ dependencies = [
 [[package]]
 name = "lnpbp"
 version = "0.4.0-beta"
-source = "git+https://github.com/LNP-BP/rust-lnpbp#0ccced3445dd5ad76f76c436c00596a926aa3cad"
+source = "git+https://github.com/LNP-BP/rust-lnpbp#ce914435ddf2089c9f903463d53d6ac79da7c34b"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -888,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-src"
-version = "111.13.0+1.1.1i"
+version = "111.14.0+1.1.1j"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
 dependencies = [
  "cc",
 ]
@@ -908,6 +1029,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "parse_arg"
@@ -956,6 +1083,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,7 +1152,7 @@ dependencies = [
  "fuchsia-cprng",
  "libc",
  "rand_core 0.3.1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1020,7 +1171,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1115,7 +1266,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1129,7 +1280,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1181,7 +1332,7 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 [[package]]
 name = "rgb-core"
 version = "0.4.0-beta"
-source = "git+https://github.com/rgb-org/rgb-core#5984c301c583161643cbecd3ae20405399f43ab4"
+source = "git+https://github.com/rgb-org/rgb-core#bf1bac19a27ec9a974d5d2412085d9081f9f3fcb"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -1189,6 +1340,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes",
  "chrono",
+ "clap",
  "deflate",
  "descriptor-wallet",
  "ed25519-dalek",
@@ -1202,9 +1354,26 @@ dependencies = [
  "num-traits",
  "regex",
  "serde",
+ "serde_json",
  "serde_with",
  "serde_with_macros",
+ "serde_yaml",
  "strict_encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1223,10 +1392,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secp256k1"
@@ -1402,6 +1594,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30f86c7635fadf2814201a4f67efefb0007588ae7422ce299f354ab5c97f61ae"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "strict_encoding"
 version = "1.1.0"
 dependencies = [
@@ -1471,6 +1681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1745,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,7 +1779,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1637,6 +1871,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,10 +1905,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.2.0"
+name = "untrusted"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1676,6 +1928,12 @@ name = "vcpkg"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1696,6 +1954,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+dependencies = [
+ "quote 1.0.9",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+
+[[package]]
+name = "web-sys"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,16 +2053,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+
+[[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
 [[package]]
 name = "lnpbp"
 version = "0.4.0-beta"
+source = "git+https://github.com/LNP-BP/rust-lnpbp#0ccced3445dd5ad76f76c436c00596a926aa3cad"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -726,7 +727,6 @@ dependencies = [
 [[package]]
 name = "lnpbp"
 version = "0.4.0-beta"
-source = "git+https://github.com/LNP-BP/rust-lnpbp#0ccced3445dd5ad76f76c436c00596a926aa3cad"
 dependencies = [
  "amplify",
  "amplify_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,8 +301,8 @@ dependencies = [
 
 [[package]]
 name = "client_side_validation"
-version = "0.3.0"
-source = "git+https://github.com/LNP-BP/rust-lnpbp#ce914435ddf2089c9f903463d53d6ac79da7c34b"
+version = "0.4.0-beta"
+source = "git+https://github.com/LNP-BP/rust-lnpbp?branch=fix/commit-encode#44a2f8db6585b3a30cab1a0aca832b14d130d2d2"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -824,13 +824,14 @@ dependencies = [
 [[package]]
 name = "lnpbp"
 version = "0.4.0-beta"
+source = "git+https://github.com/LNP-BP/rust-lnpbp#ce914435ddf2089c9f903463d53d6ac79da7c34b"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bech32",
  "bitcoin",
  "bitcoin_hashes",
- "client_side_validation 0.3.0 (git+https://github.com/LNP-BP/rust-lnpbp)",
+ "client_side_validation 0.3.0",
  "deflate",
  "descriptor-wallet",
  "inflate",
@@ -847,14 +848,13 @@ dependencies = [
 [[package]]
 name = "lnpbp"
 version = "0.4.0-beta"
-source = "git+https://github.com/LNP-BP/rust-lnpbp#ce914435ddf2089c9f903463d53d6ac79da7c34b"
 dependencies = [
  "amplify",
  "amplify_derive",
  "bech32",
  "bitcoin",
  "bitcoin_hashes",
- "client_side_validation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "client_side_validation 0.4.0-beta (git+https://github.com/LNP-BP/rust-lnpbp?branch=fix/commit-encode)",
  "deflate",
  "descriptor-wallet",
  "inflate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ amplify_derive = "2.4.3"
 strict_encoding = { version = "1", features = ["miniscript"] }
 strict_encoding_derive = { version = "1" }
 lightning_encoding = { git = "https://github.com/LNP-BP/lnp-core" }
-client_side_validation = { version = "0.3" }
+client_side_validation = { git = "https://github.com/LNP-BP/rust-lnpbp" }
 descriptor-wallet = { git = "https://github.com/LNP-BP/descriptor-wallet" }
 # Dependencies on core rust-bitcoin ecosystem projects
 # ----------------------------------------------------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ amplify_derive = "2.4.3"
 strict_encoding = { version = "1", features = ["miniscript"] }
 strict_encoding_derive = { version = "1" }
 lightning_encoding = { git = "https://github.com/LNP-BP/lnp-core" }
-client_side_validation = { git = "https://github.com/LNP-BP/rust-lnpbp" }
+client_side_validation = { git = "https://github.com/LNP-BP/rust-lnpbp", branch = "fix/commit-encode" }
 descriptor-wallet = { git = "https://github.com/LNP-BP/descriptor-wallet" }
 # Dependencies on core rust-bitcoin ecosystem projects
 # ----------------------------------------------------

--- a/client_side_validation/Cargo.toml
+++ b/client_side_validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client_side_validation"
-version = "0.3.0"
+version = "0.4.0-beta"
 license = "Apache-2.0"
 authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 description = "Client-side validation library"

--- a/client_side_validation/src/client_side_validation.rs
+++ b/client_side_validation/src/client_side_validation.rs
@@ -105,6 +105,16 @@ pub mod commit_strategy {
         }
     }
 
+    impl<K, V> CommitEncode for &(K, V)
+    where
+        K: CommitEncode,
+        V: CommitEncode,
+    {
+        fn commit_encode<E: io::Write>(&self, mut e: E) -> usize {
+            self.0.commit_encode(&mut e) + self.1.commit_encode(&mut e)
+        }
+    }
+
     impl<K, V> CommitEncode for (K, V)
     where
         K: CommitEncode,

--- a/client_side_validation/src/commit_encode.rs
+++ b/client_side_validation/src/commit_encode.rs
@@ -17,9 +17,13 @@ use bitcoin_hashes::{sha256, sha256d, Hash, HashEngine};
 
 use super::commit_verify::{self, CommitVerify};
 
-// TODO: Refactor all `CommitEncode`s into not requiring cloning
 pub trait CommitEncode {
     fn commit_encode<E: io::Write>(&self, e: E) -> usize;
+    fn commit_serialize(&self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        self.commit_encode(&mut vec);
+        vec
+    }
 }
 
 pub trait CommitEncodeWithStrategy {

--- a/client_side_validation/src/commit_encode.rs
+++ b/client_side_validation/src/commit_encode.rs
@@ -461,11 +461,11 @@ mod test {
             original.strict_serialize().unwrap()
         );
         assert_eq!(
-            "d88abaa2e8d2222c98a3596abbe99bf40aef7b95db93552a1fd9e1610fb2c6cb",
+            "b497ced8b6431336e4c66ffd56a504633c828ea3ec0c0495a31e9a14cb066406",
             collection.commit_serialize().to_hex()
         );
         assert_eq!(
-            "c10a53779cb10d64268deb4b16d0ddcc02fa81143755d84c40725b4345a2f2e8",
+            "066406cb149a1ea395040ceca38e823c6304a556fd6fc6e4361343b6d8ce97b4",
             collection.consensus_commit().to_hex()
         );
         assert_ne!(
@@ -473,7 +473,7 @@ mod test {
             original.strict_serialize().unwrap()
         );
         assert_eq!(
-            MerkleNode::hash(&collection.commit_serialize()),
+            MerkleNode::from_slice(&collection.commit_serialize()).unwrap(),
             collection.consensus_commit()
         );
 
@@ -494,11 +494,11 @@ mod test {
             original.strict_serialize().unwrap()
         );
         assert_eq!(
-            "bb929db2825f7a9a8f98dd8bc9b919a402db6c3803a45c9632108e9616cb9da5",
+            "8a8ebc499d146b0ab551e0ff985cf8166dc05f20f04b0f5991c4b9242dbde205",
             vec.commit_serialize().to_hex()
         );
         assert_eq!(
-            "2a5dd4bff32d99ff57da825288bbe240645816ea53501d19fab2c53cdc56d574",
+            "05e2bd2d24b9c491590f4bf0205fc06d16f85c98ffe051b50a6b149d49bc8e8a",
             vec.consensus_commit().to_hex()
         );
         assert_ne!(
@@ -506,7 +506,7 @@ mod test {
             original.strict_serialize().unwrap()
         );
         assert_eq!(
-            MerkleNode::hash(&vec.commit_serialize()),
+            MerkleNode::from_slice(&vec.commit_serialize()).unwrap(),
             vec.consensus_commit()
         );
         assert_ne!(vec.consensus_commit(), collection.consensus_commit());

--- a/client_side_validation/src/commit_encode.rs
+++ b/client_side_validation/src/commit_encode.rs
@@ -353,10 +353,7 @@ where
     }
 }
 
-pub trait ToMerkleSource
-where
-    Self: IntoIterator,
-{
+pub trait ToMerkleSource {
     type Leaf: ConsensusMerkleCommit;
     fn to_merkle_source(&self) -> MerkleSource<Self::Leaf>;
 }

--- a/client_side_validation/src/commit_encode.rs
+++ b/client_side_validation/src/commit_encode.rs
@@ -54,8 +54,8 @@ pub mod commit_strategy {
 
     impl<T> CommitEncode for amplify::Holder<T, UsingConceal>
     where
-        T: Conceal,
-        <T as Conceal>::Confidential: CommitEncode,
+        T: CommitConceal,
+        <T as CommitConceal>::Confidential: CommitEncode,
     {
         fn commit_encode<E: io::Write>(&self, e: E) -> usize {
             self.as_inner().conceal().commit_encode(e)
@@ -213,7 +213,7 @@ pub mod commit_strategy {
     }
 }
 
-pub trait Conceal {
+pub trait CommitConceal {
     type Confidential;
     fn conceal(&self) -> Self::Confidential;
 }
@@ -298,70 +298,3 @@ pub fn merklize(prefix: &str, data: &[MerkleNode], depth: u16) -> MerkleNode {
     }
     MerkleNode::from_engine(engine)
 }
-
-/*
-/// This simple trait MUST be used by all parties implementing client-side
-/// validation paradigm. The core concept of this paradigm is that a client
-/// must have a complete and uniform set of data, which can be represented
-/// or accessed through a single structure; and MUST be able to deterministically
-/// validate this set giving an external validation function, that is able to
-/// provide validator with
-pub trait ClientSideValidate<TR> where TR: TrustResolver {
-    type ClientData: ClientData;
-    type ValidationError: FromTrustProblem<TR> + FromInternalInconsistency<TR>;
-
-    fn new() -> Self;
-
-    fn client_side_validate(client_data: Self::ClientData, trust_resolver: TR) -> Result<(), Self::ValidationError> {
-        let validator = Self::new();
-        client_data.validate_internal_consistency()?;
-        client_data.validation_iter().try_for_each(|item| {
-            trust_resolver.resolve_trust(item, validator.get_context_for_atom(item))?;
-            item.client_side_validate()
-        })
-    }
-
-    fn get_context_for_item<C: TrustContext>(&self, data_item: Self::ClientData::ValidationItem) -> C;
-}
-
-
-pub trait ClientData {
-    type ValidationItem: ClientData;
-}
-
-pub trait TrustContext {
-
-}
-
-/// Trust resolver for a given client data type MUST work with a single type
-/// of `TrustContext`, defined by an associated type. Trust resolution MUST
-/// always produce a singular success type (defined by `()`) or fail with a
-/// well-defined type of `TrustProblem`.
-///
-/// Trust resolved may have an internal state (represented by `self` reference)
-/// and it does not require to produce a deterministic result for the same
-/// given data piece and context: the trust resolver may depend on previous
-/// operation history and depend on type and other external parameters.
-pub trait TrustResolver<T: ClientData> {
-    type TrustProblem: std::error::Error;
-    type Context: TrustContext;
-    fn resolve_trust(&self, data_piece: &T, context: &Self::Context) -> Result<(), Self::TrustProblem>;
-}
-
-
-
-mod test {
-    struct BlockchainValidator;
-    impl ClientSideValidate for BlockchainValidator {
-        type ClientData = Blockchain;
-        fn new() -> Self { Self }
-        fn get_context_for_item(&self, data_item: Block) -> Difficulty { }
-    }
-
-
-
-    fn test() {
-
-    }
-}
-*/

--- a/client_side_validation/src/lib.rs
+++ b/client_side_validation/src/lib.rs
@@ -52,5 +52,6 @@ pub mod single_use_seals;
 
 pub use crate::commit_encode::{
     commit_strategy, merklize, CommitConceal, CommitEncode,
-    CommitEncodeWithStrategy, ConsensusCommit, MerkleNode,
+    CommitEncodeWithStrategy, ConsensusCommit, MerkleNode, MerkleSource,
+    ToMerkleSource,
 };

--- a/client_side_validation/src/lib.rs
+++ b/client_side_validation/src/lib.rs
@@ -52,6 +52,6 @@ pub mod single_use_seals;
 
 pub use crate::commit_encode::{
     commit_strategy, merklize, CommitConceal, CommitEncode,
-    CommitEncodeWithStrategy, ConsensusCommit, MerkleNode, MerkleSource,
-    ToMerkleSource,
+    CommitEncodeWithStrategy, ConsensusCommit, ConsensusMerkleCommit,
+    MerkleNode, MerkleSource, ToMerkleSource,
 };

--- a/client_side_validation/src/lib.rs
+++ b/client_side_validation/src/lib.rs
@@ -42,12 +42,12 @@ extern crate amplify_derive;
 extern crate bitcoin_hashes;
 
 #[macro_use]
-mod client_side_validation;
+mod commit_encode;
 pub mod commit_verify;
 mod digests;
 pub mod single_use_seals;
 
-pub use crate::client_side_validation::{
-    commit_strategy, merklize, CommitEncode, CommitEncodeWithStrategy, Conceal,
-    ConsensusCommit, MerkleNode,
+pub use crate::commit_encode::{
+    commit_strategy, merklize, CommitConceal, CommitEncode,
+    CommitEncodeWithStrategy, ConsensusCommit, MerkleNode,
 };

--- a/client_side_validation/src/lib.rs
+++ b/client_side_validation/src/lib.rs
@@ -40,6 +40,9 @@
 extern crate amplify_derive;
 #[macro_use]
 extern crate bitcoin_hashes;
+#[cfg(test)]
+#[macro_use]
+extern crate strict_encoding;
 
 #[macro_use]
 mod commit_encode;

--- a/client_side_validation/src/trust_resolvers.rs
+++ b/client_side_validation/src/trust_resolvers.rs
@@ -1,3 +1,6 @@
+//! This is a planned API for v0.5.0 that will help structuring RGB validation
+//! into a more formal process
+
 /*
 /// This simple trait MUST be used by all parties implementing client-side
 /// validation paradigm. The core concept of this paradigm is that a client

--- a/client_side_validation/src/trust_resolvers.rs
+++ b/client_side_validation/src/trust_resolvers.rs
@@ -1,0 +1,66 @@
+/*
+/// This simple trait MUST be used by all parties implementing client-side
+/// validation paradigm. The core concept of this paradigm is that a client
+/// must have a complete and uniform set of data, which can be represented
+/// or accessed through a single structure; and MUST be able to deterministically
+/// validate this set giving an external validation function, that is able to
+/// provide validator with
+pub trait ClientSideValidate<TR> where TR: TrustResolver {
+    type ClientData: ClientData;
+    type ValidationError: FromTrustProblem<TR> + FromInternalInconsistency<TR>;
+
+    fn new() -> Self;
+
+    fn client_side_validate(client_data: Self::ClientData, trust_resolver: TR) -> Result<(), Self::ValidationError> {
+        let validator = Self::new();
+        client_data.validate_internal_consistency()?;
+        client_data.validation_iter().try_for_each(|item| {
+            trust_resolver.resolve_trust(item, validator.get_context_for_atom(item))?;
+            item.client_side_validate()
+        })
+    }
+
+    fn get_context_for_item<C: TrustContext>(&self, data_item: Self::ClientData::ValidationItem) -> C;
+}
+
+
+pub trait ClientData {
+    type ValidationItem: ClientData;
+}
+
+pub trait TrustContext {
+
+}
+
+/// Trust resolver for a given client data type MUST work with a single type
+/// of `TrustContext`, defined by an associated type. Trust resolution MUST
+/// always produce a singular success type (defined by `()`) or fail with a
+/// well-defined type of `TrustProblem`.
+///
+/// Trust resolved may have an internal state (represented by `self` reference)
+/// and it does not require to produce a deterministic result for the same
+/// given data piece and context: the trust resolver may depend on previous
+/// operation history and depend on type and other external parameters.
+pub trait TrustResolver<T: ClientData> {
+    type TrustProblem: std::error::Error;
+    type Context: TrustContext;
+    fn resolve_trust(&self, data_piece: &T, context: &Self::Context) -> Result<(), Self::TrustProblem>;
+}
+
+
+
+mod test {
+    struct BlockchainValidator;
+    impl ClientSideValidate for BlockchainValidator {
+        type ClientData = Blockchain;
+        fn new() -> Self { Self }
+        fn get_context_for_item(&self, data_item: Block) -> Difficulty { }
+    }
+
+
+
+    fn test() {
+
+    }
+}
+*/

--- a/src/seals/blind.rs
+++ b/src/seals/blind.rs
@@ -16,7 +16,7 @@ use bitcoin::secp256k1::rand::{thread_rng, RngCore};
 use bitcoin::{OutPoint, Txid};
 
 use crate::client_side_validation::{
-    commit_strategy, CommitEncodeWithStrategy, Conceal,
+    commit_strategy, CommitConceal, CommitEncodeWithStrategy,
 };
 use crate::commit_verify::CommitVerify;
 
@@ -73,15 +73,15 @@ impl From<OutPoint> for OutpointReveal {
 
 impl From<OutPoint> for OutpointHash {
     fn from(outpoint: OutPoint) -> Self {
-        OutpointReveal::from(outpoint).conceal()
+        OutpointReveal::from(outpoint).commit_conceal()
     }
 }
 
-impl Conceal for OutpointReveal {
-    type Confidential = OutpointHash;
+impl CommitConceal for OutpointReveal {
+    type ConcealedCommitment = OutpointHash;
 
     #[inline]
-    fn conceal(&self) -> Self::Confidential {
+    fn commit_conceal(&self) -> Self::ConcealedCommitment {
         self.outpoint_hash()
     }
 }


### PR DESCRIPTION
This is an alternative to #178 as a more systematic commit encoding refactoring addressing several issues and providing test coverage