### PR TITLE
Add strict_encoding_test crate to replace macros/test_helpers deprecated in strict_encoding 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "encoding_derive_helpers"
-version = "1.7.4"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af9b20816ac9126945a6ecc1e248c4a1edfeada329839cdca9c96581174bebb"
+checksum = "dc4ba8a88067b85c8714922db6e5f2af47b894d63b771dbb0c4d31d6607e9057"
 dependencies = [
  "amplify",
  "proc-macro2",
@@ -388,6 +388,7 @@ dependencies = [
  "serde",
  "serde_with",
  "strict_encoding",
+ "strict_encoding_test",
 ]
 
 [[package]]
@@ -707,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding"
-version = "1.7.4"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441080358b7382cf0b4766e4253a77e1ee7ad17139a4f0b950993074acfb63dc"
+checksum = "009561bba71cc16cdc0ef40c108cb701a782f7a10aefb28c1a72beae27b721d1"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -720,14 +721,24 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding_derive"
-version = "1.7.4"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf87ccd517175354f494683b69b7703664cf49e6b82e78ff53e42bea0c17401"
+checksum = "3bc7b868cb00c8861784b7f463c984c4b2ad20d1f23cec5997ad9cb41e559239"
 dependencies = [
  "amplify_syn",
  "encoding_derive_helpers",
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "strict_encoding_test"
+version = "1.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bd0bdf8da419af27970c9e16e99e23ec67b5c8b6896db950c93a6ba1827b2a"
+dependencies = [
+ "amplify",
+ "strict_encoding",
 ]
 
 [[package]]

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2018"
 amplify = "3.9.1"
 bitcoin = "0.27.1"
 bitcoin_hashes = "0.10.0"
-strict_encoding = "1.7.4"
+strict_encoding = "1.7.9"
+strict_encoding_test = "1.7.6"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 serde_with = { version = "1.8", features = ["hex"], optional = true }
 lazy_static = "1.4.0" # TODO: #213 Remove dependency

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -27,8 +27,6 @@
 extern crate amplify;
 #[macro_use]
 extern crate bitcoin_hashes;
-#[macro_use]
-extern crate strict_encoding;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde_crate as serde;
@@ -47,7 +45,8 @@ use bitcoin::hashes::{sha256d, Hash};
 use bitcoin::network::constants::Network;
 use bitcoin::BlockHash;
 use strict_encoding::{
-    strict_deserialize, strict_serialize, StrictDecode, StrictEncode,
+    strict_decode_self, strict_deserialize, strict_encode_list,
+    strict_serialize, StrictDecode, StrictEncode,
 };
 
 /// P2P network magic number: prefix identifying network on which node operates
@@ -1002,8 +1001,10 @@ impl FromStr for Chain {
 
 #[cfg(test)]
 mod test {
-    #![allow(deprecated)] // TODO: #210 Refactor with strict_encoding_test crate
-    use strict_encoding::test_helpers::*;
+    use strict_encoding_test::{
+        test_encoding_enum, test_encoding_enum_by_values,
+        test_encoding_enum_u8_exhaustive, test_encoding_roundtrip,
+    };
 
     use super::*;
 


### PR DESCRIPTION
Addresses #210

Added the [strict_encoding_test](https://docs.rs/strict_encoding_test/1.7.6/strict_encoding_test/) crate and replaced the macros and functions deprecated in strict_encoding since 1.6.1.

