### PR TITLE
Replace lazy_static dependency in chain crate with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
  "amplify",
  "bitcoin",
  "bitcoin_hashes",
- "lazy_static",
+ "once_cell",
  "serde",
  "serde_with",
  "strict_encoding",
@@ -423,6 +423,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "os_str_bytes"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2018"
 amplify = "3.9.1"
 bitcoin = "0.27.1"
 bitcoin_hashes = "0.10.0"
+once_cell = "1.9.0"
 strict_encoding = "1.7.4"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 serde_with = { version = "1.8", features = ["hex"], optional = true }
-lazy_static = "1.4.0" # TODO: #213 Remove dependency
 
 [features]
 serde = ["serde_crate", "serde_with", "bitcoin_hashes/serde", "bitcoin/use-serde"]

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -32,8 +32,6 @@ extern crate strict_encoding;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde_crate as serde;
-#[macro_use]
-extern crate lazy_static;
 
 use std::cmp::Ordering;
 use std::convert::TryFrom;
@@ -46,6 +44,7 @@ use bitcoin::hashes::hex::{self, FromHex, ToHex};
 use bitcoin::hashes::{sha256d, Hash};
 use bitcoin::network::constants::Network;
 use bitcoin::BlockHash;
+use once_cell::sync::Lazy;
 use strict_encoding::{
     strict_deserialize, strict_serialize, StrictDecode, StrictEncode,
 };
@@ -281,9 +280,9 @@ pub const GENESIS_HASH_LIQUIDV1: &[u8] = &[
     0x37, 0x92, 0x96, 0x88, 0x8a, 0x20, 0x60, 0x03,
 ];
 
-lazy_static! {
-    /// Bitcoin mainnet chain parameters
-    static ref CHAIN_PARAMS_MAINNET: ChainParams = ChainParams {
+/// Bitcoin mainnet chain parameters
+static CHAIN_PARAMS_MAINNET: Lazy<ChainParams> = Lazy::new(|| {
+    ChainParams {
         name: "bitcoin".to_string(),
         p2p_magic: P2pNetworkId::Mainnet,
         genesis_hash: BlockHash::from_slice(GENESIS_HASH_MAINNET)
@@ -308,10 +307,12 @@ lazy_static! {
         },
         is_testnet: false,
         is_pow: true,
-    };
+    }
+});
 
-    /// Bitcoin testnet chain parameters
-    static ref CHAIN_PARAMS_TESTNET: ChainParams = ChainParams {
+/// Bitcoin testnet chain parameters
+static CHAIN_PARAMS_TESTNET: Lazy<ChainParams> = Lazy::new(|| {
+    ChainParams {
         name: "testnet".to_string(),
         p2p_magic: P2pNetworkId::Testnet,
         genesis_hash: BlockHash::from_slice(GENESIS_HASH_TESTNET)
@@ -336,10 +337,12 @@ lazy_static! {
         },
         is_testnet: true,
         is_pow: true,
-    };
+    }
+});
 
-    /// Bitcoin regtest chain parameters
-    static ref CHAIN_PARAMS_REGTEST: ChainParams = ChainParams {
+/// Bitcoin regtest chain parameters
+static CHAIN_PARAMS_REGTEST: Lazy<ChainParams> = Lazy::new(|| {
+    ChainParams {
         name: "regtest".to_string(),
         p2p_magic: P2pNetworkId::Regtest,
         genesis_hash: BlockHash::from_slice(GENESIS_HASH_REGTEST)
@@ -363,10 +366,12 @@ lazy_static! {
         },
         is_testnet: true,
         is_pow: false,
-    };
+    }
+});
 
-    /// Bitcoin signet chain parameters
-    static ref CHAIN_PARAMS_SIGNET: ChainParams = ChainParams {
+/// Bitcoin signet chain parameters
+static CHAIN_PARAMS_SIGNET: Lazy<ChainParams> = Lazy::new(|| {
+    ChainParams {
         name: "signet".to_string(),
         p2p_magic: P2pNetworkId::Signet,
         genesis_hash: BlockHash::from_slice(GENESIS_HASH_SIGNET)
@@ -390,10 +395,12 @@ lazy_static! {
         },
         is_testnet: true,
         is_pow: false,
-    };
+    }
+});
 
-    /// Liquid V1 chain parameters
-    static ref CHAIN_PARAMS_LIQUIDV1: ChainParams = ChainParams {
+/// Liquid V1 chain parameters
+static CHAIN_PARAMS_LIQUIDV1: Lazy<ChainParams> = Lazy::new(|| {
+    ChainParams {
         name: "liquidv1".to_string(),
         // TODO #216: check Liquid network magic number and change this if needed
         p2p_magic: P2pNetworkId::Mainnet,
@@ -418,8 +425,8 @@ lazy_static! {
         },
         is_testnet: false,
         is_pow: false,
-    };
-}
+    }
+});
 
 /// Enum identifying format for transaction & block structure in a given chain.
 /// Right now only two structures are supported: Bitcoin format and

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -315,8 +315,9 @@ static CHAIN_PARAMS_TESTNET: Lazy<ChainParams> = Lazy::new(|| {
     ChainParams {
         name: "testnet".to_string(),
         p2p_magic: P2pNetworkId::Testnet,
-        genesis_hash: BlockHash::from_slice(GENESIS_HASH_TESTNET)
-            .expect("Bitcoin testnet genesis hash contains invalid binary data"),
+        genesis_hash: BlockHash::from_slice(GENESIS_HASH_TESTNET).expect(
+            "Bitcoin testnet genesis hash contains invalid binary data",
+        ),
         bip70_name: "test".to_string(),
         bip173_prefix: "tb".to_string(),
         p2p_port: 18333,
@@ -331,8 +332,9 @@ static CHAIN_PARAMS_TESTNET: Lazy<ChainParams> = Lazy::new(|| {
             unit_of_accounting: "Test Bitcoin".to_string(),
             indivisible_unit: "Test satoshi".to_string(),
             divisibility: 100_000_000,
-            asset_id: AssetId::from_slice(GENESIS_HASH_TESTNET)
-                .expect("Bitcoin testnet genesis hash contains invalid binary data"),
+            asset_id: AssetId::from_slice(GENESIS_HASH_TESTNET).expect(
+                "Bitcoin testnet genesis hash contains invalid binary data",
+            ),
             asset_system: AssetSystem::NativeBlockchain,
         },
         is_testnet: true,
@@ -341,68 +343,66 @@ static CHAIN_PARAMS_TESTNET: Lazy<ChainParams> = Lazy::new(|| {
 });
 
 /// Bitcoin regtest chain parameters
-static CHAIN_PARAMS_REGTEST: Lazy<ChainParams> = Lazy::new(|| {
-    ChainParams {
-        name: "regtest".to_string(),
-        p2p_magic: P2pNetworkId::Regtest,
-        genesis_hash: BlockHash::from_slice(GENESIS_HASH_REGTEST)
-            .expect("Bitcoin regtest genesis hash contains invalid binary data"),
-        bip70_name: "regtest".to_string(),
-        bip173_prefix: "tb".to_string(),
-        p2p_port: 28333,
-        rpc_port: 28332,
-        ln_height: 1,
-        rgb_height: 1,
-        format: ChainFormat::Bitcoin,
-        dust_limit: 546,
-        native_asset: AssetParams {
-            ticker: "tBTC".to_string(),
-            unit_of_accounting: "Test Bitcoin".to_string(),
-            indivisible_unit: "Test satoshi".to_string(),
-            divisibility: 100_000_000,
-            asset_id: AssetId::from_slice(GENESIS_HASH_REGTEST)
-                .expect("Bitcoin regtest genesis hash contains invalid binary data"),
-            asset_system: AssetSystem::NativeBlockchain,
-        },
-        is_testnet: true,
-        is_pow: false,
-    }
+static CHAIN_PARAMS_REGTEST: Lazy<ChainParams> = Lazy::new(|| ChainParams {
+    name: "regtest".to_string(),
+    p2p_magic: P2pNetworkId::Regtest,
+    genesis_hash: BlockHash::from_slice(GENESIS_HASH_REGTEST)
+        .expect("Bitcoin regtest genesis hash contains invalid binary data"),
+    bip70_name: "regtest".to_string(),
+    bip173_prefix: "tb".to_string(),
+    p2p_port: 28333,
+    rpc_port: 28332,
+    ln_height: 1,
+    rgb_height: 1,
+    format: ChainFormat::Bitcoin,
+    dust_limit: 546,
+    native_asset: AssetParams {
+        ticker: "tBTC".to_string(),
+        unit_of_accounting: "Test Bitcoin".to_string(),
+        indivisible_unit: "Test satoshi".to_string(),
+        divisibility: 100_000_000,
+        asset_id: AssetId::from_slice(GENESIS_HASH_REGTEST).expect(
+            "Bitcoin regtest genesis hash contains invalid binary data",
+        ),
+        asset_system: AssetSystem::NativeBlockchain,
+    },
+    is_testnet: true,
+    is_pow: false,
 });
 
 /// Bitcoin signet chain parameters
-static CHAIN_PARAMS_SIGNET: Lazy<ChainParams> = Lazy::new(|| {
-    ChainParams {
-        name: "signet".to_string(),
-        p2p_magic: P2pNetworkId::Signet,
-        genesis_hash: BlockHash::from_slice(GENESIS_HASH_SIGNET)
+static CHAIN_PARAMS_SIGNET: Lazy<ChainParams> = Lazy::new(|| ChainParams {
+    name: "signet".to_string(),
+    p2p_magic: P2pNetworkId::Signet,
+    genesis_hash: BlockHash::from_slice(GENESIS_HASH_SIGNET)
+        .expect("Bitcoin signet genesis hash contains invalid binary data"),
+    bip70_name: "signet".to_string(),
+    bip173_prefix: "tb".to_string(),
+    p2p_port: 38333,
+    rpc_port: 38332,
+    ln_height: 1,
+    rgb_height: 1,
+    format: ChainFormat::Bitcoin,
+    dust_limit: 546,
+    native_asset: AssetParams {
+        ticker: "sBTC".to_string(),
+        unit_of_accounting: "Signet Bitcoin".to_string(),
+        indivisible_unit: "Signet satoshi".to_string(),
+        divisibility: 100_000_000,
+        asset_id: AssetId::from_slice(GENESIS_HASH_SIGNET)
             .expect("Bitcoin signet genesis hash contains invalid binary data"),
-        bip70_name: "signet".to_string(),
-        bip173_prefix: "tb".to_string(),
-        p2p_port: 38333,
-        rpc_port: 38332,
-        ln_height: 1,
-        rgb_height: 1,
-        format: ChainFormat::Bitcoin,
-        dust_limit: 546,
-        native_asset: AssetParams {
-            ticker: "sBTC".to_string(),
-            unit_of_accounting: "Signet Bitcoin".to_string(),
-            indivisible_unit: "Signet satoshi".to_string(),
-            divisibility: 100_000_000,
-            asset_id: AssetId::from_slice(GENESIS_HASH_SIGNET)
-                .expect("Bitcoin signet genesis hash contains invalid binary data"),
-            asset_system: AssetSystem::NativeBlockchain,
-        },
-        is_testnet: true,
-        is_pow: false,
-    }
+        asset_system: AssetSystem::NativeBlockchain,
+    },
+    is_testnet: true,
+    is_pow: false,
 });
 
 /// Liquid V1 chain parameters
 static CHAIN_PARAMS_LIQUIDV1: Lazy<ChainParams> = Lazy::new(|| {
     ChainParams {
         name: "liquidv1".to_string(),
-        // TODO #216: check Liquid network magic number and change this if needed
+        // TODO #216: check Liquid network magic number and change this if
+        // needed
         p2p_magic: P2pNetworkId::Mainnet,
         genesis_hash: BlockHash::from_slice(GENESIS_HASH_LIQUIDV1)
             .expect("Liquid V1 genesis hash contains invalid binary data"),


### PR DESCRIPTION
~~Addresses #213~~

This PR replaces usage of the `lazy_static!` macro with the `once_cell::sync::Lazy` type. This accomplishes the same goals as `lazy_static!` by [lazily initializing global data](https://docs.rs/once_cell/1.9.0/once_cell/#lazy-initialized-global-data). `once_cell` has the following advantages over `lazy_static`:
* `once_cell` has seen more recent active development
  * [once_cell = "1.9.0"](https://crates.io/crates/once_cell/1.9.0) was released about 1 month ago
  * [lazy_static = "1.4.0"](https://crates.io/crates/lazy_static/1.4.0) was released over 2 years ago
* `once_cell` functionality is in the current nightly build of Rust - [tracking issue](https://github.com/rust-lang/rust/issues/74465)

Other comparisons between the two libraries
* All-time downloads (according to crates.io):
  * [once_cell](https://crates.io/crates/once_cell) = ~40 million 
  * [lazy_static](https://crates.io/crates/lazy_static) = ~70 million
* Github contributors/stars
  * [once_cell](https://github.com/matklad/once_cell) = 34 contributors, 931 stars
  * [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs) = 47 contributors, 1.3k stars